### PR TITLE
fix race condition, output non-inverted, filegrp directory, pageId

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ cache:
     - local
     - repo
 install:
+  - sudo apt update
+  - sudo apt install libmagick++-dev libgraphicsmagick++1-dev libboost-dev libtesseract-dev graphviz
   - pip install ocrd
   - make build-olena
   - export PATH="$PWD/local/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX = $(PWD)/local
+PREFIX ?= $(PWD)/local
 BINDIR = $(PREFIX)/bin
 SHAREDIR = $(PREFIX)/share/ocrd_olena
 
@@ -19,6 +19,7 @@ help:
 	@echo "  Variables"
 	@echo ""
 	@echo "    OLENA_VERSION  Olena version to use ('$(OLENA_VERSION)')"
+	@echo "    PREFIX         directory to to install ('$(PREFIX)')"
 
 # END-EVAL
 
@@ -38,7 +39,7 @@ olena-git:
 	git clone git://git.lrde.epita.fr/olena olena-git
 
 deps-ubuntu:
-	sudo apt install libmagick++-dev `grep -q 18.04 /etc/*release || libtesseract3-dev`
+	sudo apt install libmagick++-dev libboost-dev `grep -q 18.04 /etc/*release || echo libtesseract-dev`
 
 deps: deps-ubuntu
 	which scribo-cli || $(MAKE) build-olena
@@ -51,6 +52,7 @@ install:
 		sed 's,^SHAREDIR=.*,SHAREDIR="$(SHAREDIR)",' $$tool > $(BINDIR)/$$tool ;\
 		chmod a+x $(BINDIR)/$$tool ;\
 	done
+	@echo "you might want to add '$(BINDIR)' to your path"
 
 # Build olena and scribo
 build-olena: $(OLENA_DIR)

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,8 @@ olena-git:
 	git clone git://git.lrde.epita.fr/olena olena-git
 
 deps-ubuntu:
-	apt install libmagick++-dev libgraphicsmagick++1-dev libboost-dev `grep -q 18.04 /etc/*release || echo libtesseract-dev`
+	apt install libmagick++-dev libgraphicsmagick++1-dev libboost-dev \
+	`grep -q 18.04 /etc/*release || echo libtesseract-dev` graphviz
 
 deps: #deps-ubuntu
 	test -x $(BINDIR)/scribo-cli && \

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -16,11 +16,12 @@ main () {
     mkdir -p $out_file_grp
 
     local IFS=$'\n'
-    files=($(ocrd workspace find           \
-        -G $in_file_grp \
+    files=($(ocrd workspace find     \
+        -G $in_file_grp              \
         -k local_filename            \
         -k ID                        \
         -k mimetype                  \
+        -k pageId                    \
         --download))
     for csv in "${files[@]}"; do
         # Parse comma separated fields
@@ -30,6 +31,7 @@ main () {
         local in_fpath="${fields[0]}"
         local in_id="${fields[1]}"
         local in_mimetype="${fields[2]}"
+        local in_pageId="${fields[3]:-}"
 
         local out_id="${in_id//$in_file_grp/$out_file_grp}-${params[impl]}"
         local out_fpath="$out_file_grp/${out_id}.png"
@@ -44,11 +46,20 @@ main () {
         rm "$out_fpath.pbm" 
 
         # Add files
+        if test -z "$in_pageId"; then
         ocrd workspace add   \
             -G $out_file_grp \
             -m image/png     \
             -i "$out_id"     \
             "$out_fpath"
+        else
+        ocrd workspace add   \
+            -G $out_file_grp \
+            -g $in_pageId    \
+            -m image/png     \
+            -i "$out_id"     \
+            "$out_fpath"
+        fi
     done
 }
 

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -18,13 +18,14 @@ main () {
 
     cd "${ocrd__argv[working_dir]}"
 
-    ocrd workspace find              \
+    local IFS=$'\n'
+    files=($(ocrd workspace find           \
         -G "${ocrd__argv[input_file_grp]}" \
         -k local_filename            \
         -k ID                        \
         -k mimetype                  \
-        --download                   \
-    | while read -r csv;do
+        --download))
+    for csv in "${files[@]}"; do
         # Parse comma separated fields
         local IFS=$'\t'
         local fields=($csv)

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -43,7 +43,7 @@ main () {
         scribo-cli "${params[impl]}" "$in_fpath" "$out_fpath.pbm"
 
         # Convert PBM to PNG
-        convert  "$out_fpath.pbm" "$out_fpath"
+        convert "$out_fpath.pbm" -negate "$out_fpath"
 
         # Remove PBM
         rm "$out_fpath.pbm" 

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -9,6 +9,7 @@ SHAREDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 declare -A mimetype2extension=(
     ['image/tiff']='.tiff'
     ['image/jp2']='.jp2'
+    ['image/jpeg']='.jpg'
     ['image/png']='.png'
 )
 
@@ -33,7 +34,7 @@ main () {
         local in_fpath="${fields[0]}"
         local in_id="${fields[1]}"
         local in_mimetype="${fields[2]}"
-        local in_extension=${mimetype2extension[$in_mimetype]}
+        local in_extension=${mimetype2extension[$in_mimetype]:?"unknown MIME type: '$in_mimetype'"}
 
         local out_fpath="${in_fpath%$in_extension}.${params[impl]}.png"
         local out_id="$in_id-${params[impl]}"

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -6,22 +6,18 @@ which ocrd >/dev/null 2>/dev/null || { echo "ocrd not in \$PATH. Panicking"; exi
 
 SHAREDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 
-declare -A mimetype2extension=(
-    ['image/tiff']='.tiff'
-    ['image/jp2']='.jp2'
-    ['image/jpeg']='.jpg'
-    ['image/png']='.png'
-)
-
 main () {
     source `ocrd bashlib filename`
     ocrd__wrap "$SHAREDIR/ocrd-tool.json" "ocrd-olena-binarize" "$@"
 
     cd "${ocrd__argv[working_dir]}"
+    in_file_grp=${ocrd__argv[input_file_grp]}
+    out_file_grp=${ocrd__argv[output_file_grp]}
+    mkdir -p $out_file_grp
 
     local IFS=$'\n'
     files=($(ocrd workspace find           \
-        -G "${ocrd__argv[input_file_grp]}" \
+        -G $in_file_grp \
         -k local_filename            \
         -k ID                        \
         -k mimetype                  \
@@ -34,10 +30,9 @@ main () {
         local in_fpath="${fields[0]}"
         local in_id="${fields[1]}"
         local in_mimetype="${fields[2]}"
-        local in_extension=${mimetype2extension[$in_mimetype]:?"unknown MIME type: '$in_mimetype'"}
 
-        local out_fpath="${in_fpath%$in_extension}.${params[impl]}.png"
-        local out_id="$in_id-${params[impl]}"
+        local out_id="${in_id//$in_file_grp/$out_file_grp}-${params[impl]}"
+        local out_fpath="$out_file_grp/${out_id}.png"
 
         # Binarize as PBM
         scribo-cli "${params[impl]}" "$in_fpath" "$out_fpath.pbm"
@@ -49,10 +44,10 @@ main () {
         rm "$out_fpath.pbm" 
 
         # Add files
-        ocrd workspace add                \
-            -G "${ocrd__argv[output_file_grp]}" \
-            -m image/png                  \
-            -i "$out_id"                  \
+        ocrd workspace add   \
+            -G $out_file_grp \
+            -m image/png     \
+            -i "$out_id"     \
             "$out_fpath"
     done
 }

--- a/ocrd-tool.json
+++ b/ocrd-tool.json
@@ -4,12 +4,18 @@
   "tools": {
     "ocrd-olena-binarize": {
       "executable": "ocrd-olena-binarize",
-      "description": "OLENA's binarization algos for OCR-D",
+      "description": "OLENA's binarization algos for OCR-D (on page-level)",
       "categories": [
         "Image preprocessing"
       ],
       "steps": [
         "preprocessing/optimization/binarization"
+      ],
+      "input_file_grp": [
+        "OCR-D-IMG"
+      ],
+      "output_file_grp": [
+        "OCR-D-IMG-BIN"
       ],
       "parameters": {
         "impl": {

--- a/ocrd-tool.json
+++ b/ocrd-tool.json
@@ -22,7 +22,7 @@
           "description": "The name of the actual binarization algorithm",
           "type": "string",
           "required": true,
-          "enum": ["sauvola", "sauvola-ms", "sauvola-ms-fg", "sauvola-ms-split", "kim", "wolf"]
+          "enum": ["sauvola", "sauvola-ms", "sauvola-ms-fg", "sauvola-ms-split", "kim", "wolf", "niblack", "singh", "otsu"]
         },
         "win-size": {
           "description": "Window size",

--- a/ocrd-tool.json
+++ b/ocrd-tool.json
@@ -16,7 +16,7 @@
           "description": "The name of the actual binarization algorithm",
           "type": "string",
           "required": true,
-          "enum": ["sauvola", "sauvola-ms", "sauvola-ms-fg", "sauvola-ms-split"]
+          "enum": ["sauvola", "sauvola-ms", "sauvola-ms-fg", "sauvola-ms-split", "kim", "wolf"]
         },
         "win-size": {
           "description": "Window size",

--- a/olena-configure-boost.patch
+++ b/olena-configure-boost.patch
@@ -1,0 +1,19 @@
+*** configure
+--- configure
+***************
+*** 15932,15938 ****
+      done
+      done
+  ac_ext=cpp
+! ac_cpp='$CXXCPP $CPPFLAGS'
+  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+  ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+  ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+--- 15932,15938 ----
+      done
+      done
+  ac_ext=cpp
+! ac_cpp='$CXXCPP $CPPFLAGS -P'
+  ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+  ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+  ac_compiler_gnu=$ac_cv_cxx_compiler_gnu

--- a/test/test.sh
+++ b/test/test.sh
@@ -7,6 +7,7 @@ export workspace_dir="/tmp/test-ocrd-olena-binarize"
 # Init workspace
 rm -rf "$workspace_dir"
 ocrd workspace clone -a "$assets/scribo-test/data/mets.xml" "$workspace_dir"
+cp -rt "$workspace_dir" "$assets/scribo-test/data/OCR-D-IMG" 
 
 declare -a algos=(sauvola sauvola-ms-fg sauvola-ms sauvola-ms-split)
 for algo in "${algos[@]}";do

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
+set -e
 export PATH="$PWD/..:$PWD/../local/bin:$PATH"
 export assets="$PWD/assets"
 export workspace_dir="/tmp/test-ocrd-olena-binarize"
 
 # Init workspace
 rm -rf "$workspace_dir"
-ocrd workspace init "$workspace_dir"
-ocrd workspace -d "$workspace_dir" add -G OCR-D-IMG -i orig -m image/tiff "$assets/scribo-test/orig.tiff"
+ocrd workspace clone -a "$assets/scribo-test/data/mets.xml" "$workspace_dir"
 
 declare -a algos=(sauvola sauvola-ms-fg sauvola-ms sauvola-ms-split)
 for algo in "${algos[@]}";do
@@ -20,8 +20,8 @@ done
 
 for algo in "${algos[@]}";do
     echo >&2 "# Diffing $algo"
-    should=$(wc -c "$workspace_dir"/OCR-D-IMG-BIN/*$algo.png | grep -o '^[0-9]*')
-    actual=$(wc -c "$assets/scribo-test/orig.${algo}.png" | grep -o '^[0-9]*')
+    should=$(wc -c "$workspace_dir"/OCR-D-IMG-BIN-${algo}/*.png | grep -o '^[0-9]*')
+    actual=$(wc -c "$assets"/scribo-test/data/OCR-D-IMG-BIN-${algo^^}/* | grep -o '^[0-9]*')
     if [[ $should != $actual ]];then
         echo "not ok - $algo: Expected $should but is $actual"
     else


### PR DESCRIPTION
Mind you: the tests currently _do not_ pass, but only because we now expect the positive (not the inverted) images as results – see OCR-D/assets#36