### PR TITLE
make binarize process PAGE-XML (with AlternativeImage):

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ cache:
 install:
   - sudo apt update
   - sudo make deps-ubuntu
-  - pip install ocrd
-  - make build-olena
+  - make deps
   - export PATH="$PWD/local/bin:$PATH"
 script:
   - make assets test OCRD_BASEURL="https://github.com/OCR-D/ocrd-assets/raw/master/data/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
     - repo
 install:
   - sudo apt update
-  - sudo apt install libmagick++-dev libgraphicsmagick++1-dev libboost-dev libtesseract-dev graphviz
+  - sudo make deps-ubuntu
   - pip install ocrd
   - make build-olena
   - export PATH="$PWD/local/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ deps: #deps-ubuntu
 	test -x $(BINDIR)/scribo-cli && \
 	$(BINDIR)/scribo-cli sauvola --help >/dev/null 2>&1 || \
 	$(MAKE) build-olena
+	pip3 install --pre ocrd # needed for ocrd CLI (and bashlib)
 
 # Install
 install: deps

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ olena-git:
 
 deps-ubuntu:
 	apt install libmagick++-dev libgraphicsmagick++1-dev libboost-dev \
-	`grep -q 18.04 /etc/*release || echo libtesseract-dev` graphviz
+	`grep -q 18.04 /etc/*release || echo libtesseract-dev` graphviz xmlstarlet
 
 deps: #deps-ubuntu
 	test -x $(BINDIR)/scribo-cli && \

--- a/README.md
+++ b/README.md
@@ -4,10 +4,78 @@
 
 [![Build Status](https://travis-ci.org/OCR-D/ocrd_olena.svg?branch=master)](https://travis-ci.org/OCR-D/ocrd_olena)
 
+## Requirements
+
+```
+make deps-ubuntu
+```
+
+...will try to install the required packages on Ubuntu.
+
 ## Installation
 
 ```
-make build-olena
+make install
 ```
 
-Will download and build olena/scribo from source
+...will download, patch and build olena/scribo from source, and install locally (in a path relative to the CWD).
+
+## Testing
+
+```
+make test
+```
+
+...will clone the assets repository from Github, make a workspace copy, and run checksum tests for binarization on them.
+
+## Usage
+
+This package has the following user interfaces:
+
+### [OCR-D processor](https://github.com/OCR-D/core) interface `ocrd-olena-binarize`
+
+To be used with [PageXML](https://www.primaresearch.org/tools/PAGELibraries) documents in an [OCR-D](https://github.com/OCR-D/spec/) annotation workflow. Input could be any valid workspace with source images available. Currently covers the `Page` hierarchy level only. Uses either (the last) `AlternativeImage`, if any, or `imageFilename`, otherwise. Adds an `AlternativeImage` with the result of binarization for every page.
+
+```json
+    "ocrd-olena-binarize": {
+      "executable": "ocrd-olena-binarize",
+      "description": "OLENA's binarization algos for OCR-D (on page-level)",
+      "categories": [
+        "Image preprocessing"
+      ],
+      "steps": [
+        "preprocessing/optimization/binarization"
+      ],
+      "input_file_grp": [
+        "OCR-D-SEG-BLOCK",
+        "OCR-D-SEG-LINE",
+        "OCR-D-SEG-WORD",
+        "OCR-D-IMG"
+      ],
+      "output_file_grp": [
+        "OCR-D-SEG-BLOCK",
+        "OCR-D-SEG-LINE",
+        "OCR-D-SEG-WORD"
+      ],
+      "parameters": {
+        "impl": {
+          "description": "The name of the actual binarization algorithm",
+          "type": "string",
+          "required": true,
+          "enum": ["sauvola", "sauvola-ms", "sauvola-ms-fg", "sauvola-ms-split", "kim", "wolf", "niblack", "singh", "otsu"]
+        },
+        "win-size": {
+          "description": "Window size",
+          "type": "number",
+          "format": "integer",
+          "default": 101
+        },
+        "k": {
+          "description": "Sauvola's formulae parameter",
+          "format": "float",
+          "type": "number",
+          "default": 0.34
+        }
+      }
+    }
+```

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -35,13 +35,52 @@ function call_scribo {
     convert "${3}.pbm" -negate "$3"
 
     # Remove PBM
-    rm "${3}.pbm" 
+    rm "${3}.pbm"
+
+    if [[ $(basename "$2") =~ ocrd-olena-binarize-cropped.* ]]; then
+        rm "$2"
+    fi
 }
 
-function modify_page {
-    local namespace="$1" ns_prefix="$2" image_out_fpath="$3" out_fpath="$4"
+function xywh_from_points {
+    # FIXME: add a bashlib wrapper for utils (coordinate conversion) to use here
+    minx=$((2**32))
+    miny=$((2**32))
+    maxx=0
+    maxy=0
+    for point in $*; do
+        pointx=${point%,*}
+        pointy=${point#*,}
+        [[ $pointx -lt $minx ]] && minx=$pointx
+        [[ $pointx -gt $maxx ]] && maxx=$pointx
+        [[ $pointy -lt $miny ]] && miny=$pointy
+        [[ $pointy -gt $maxy ]] && maxy=$pointy
+    done
+    echo $(($maxx - $minx)) $((maxy - $miny)) $minx $miny
+}
 
-    local IFS=$' \t\n'
+function image_id_from_fpath {
+    local image_in_fpath="$1" in_id="$2" in_pageId="$3"
+    
+    # find image ID representing the image file in METS
+    # FIXME: add a bashlib wrapper for constants (METS tags) to use here
+    # FIXME: extend `ocrd workspace find` with a filter option for FLocat to use here
+    options=( sel
+              -N mets=http://www.loc.gov/METS/
+              -N xlink=http://www.w3.org/1999/xlink
+              -t -v "//mets:file[starts-with(@MIMETYPE,'image/') and ./mets:FLocat/@xlink:href='${image_in_fpath}']/@ID"
+              "${ocrd__argv[mets_file]}" )
+    if ! image_in_id=$(xmlstarlet "${options[@]}"); then
+        echo "WARNING: image URL '${image_in_fpath}' not referenced"\
+             "in METS for input file ID=${in_id} (pageId=${in_pageId})" >&2
+        image_in_id="${in_id}-IMG" # fallback
+    fi
+    echo "$image_in_id"
+}   
+
+function modify_page {
+    local namespace="$1" ns_prefix="$2" image_out_fpath="$3" out_fpath="$4" comments="$5"
+
     declare -a options
     options+=( --no-doc-namespace ed --inplace
                -N pc="${namespace}"
@@ -89,14 +128,14 @@ function modify_page {
                -s '$new-image' -t attr -n filename
                                -v "$image_out_fpath"
                -s '$new-image' -t attr -n comments
-                               -v "binarized"
+                               -v "$comments"
                                "$out_fpath" )
     xmlstarlet "${options[@]}"
 }
 
 function process_pagefile {
     local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5" image_out_file_grp="$6"
-    local image_in_fpath image_in_id image_out_fpath image_out_id
+    local image_in_fpath image_in_id image_out_fpath image_out_id comments
     
     if (($PRESERVE_NAMESPACE)); then
         # preserve namespace and prefix
@@ -142,6 +181,12 @@ EOF
        image_in_fpath=$(xmlstarlet "${options[@]}"); then
         echo "INFO: found AlternativeImage filename '${image_in_fpath}'"\
              "for input file ID=${in_id} (pageId=${in_pageId})" >&2
+        image_in_id=$(image_id_from_fpath "$image_in_fpath" "$in_id" "$in_pageId")
+        options=( --no-doc-namespace sel
+                  -N pc="${namespace}" -t 
+                  -v '/pc:PcGts/pc:Page/pc:AlternativeImage[last()]/@comments' 
+                  "$out_fpath" )
+        comments=$(xmlstarlet "${options[@]}"),binarized
     else
         options=( --no-doc-namespace sel
                   -N pc="${namespace}" -t
@@ -150,21 +195,26 @@ EOF
         image_in_fpath=$(xmlstarlet "${options[@]}")
         echo "INFO: found imageFilename '${image_in_fpath}'"\
              "for input file ID=${in_id} (pageId=${in_pageId})" >&2
+        image_in_id=$(image_id_from_fpath "$image_in_fpath" "$in_id" "$in_pageId")
+        if options=( --no-doc-namespace sel
+                     -N pc="${namespace}" -t
+                     -v '(/pc:PcGts/pc:Page/pc:Border|/pc:PcGts/pc:Page/pc:PrintSpace)/pc:Coords/@points'
+                     "$out_fpath" )
+           border=$(xmlstarlet "${options[@]}"); then
+            echo "DEBUG: Using explictly set page border '$border'"\
+                 "for input file ID=${in_id} (pageId=${in_pageId})" >&2
+            local tmpfile=$(mktemp --tmpdir ocrd-olena-binarize-cropped.XXXXXX)
+            xywh_from_points $border | {
+                read width height left top 
+                convert "$image_in_fpath" -crop ${width}x${height}+${left}+${top} "$tmpfile"
+            }
+            image_in_fpath="$tmpfile"
+            comments="cropped,binarized"
+        else
+            comments="binarized"
+        fi
     fi
 
-    # find image file representing the page in METS
-    # FIXME: add a bashlib wrapper for constants (METS tags) to use here
-    options=( sel
-              -N mets=http://www.loc.gov/METS/
-              -N xlink=http://www.w3.org/1999/xlink
-              -t -v "//mets:file[starts-with(@MIMETYPE,'image/') and ./mets:FLocat/@xlink:href='${image_in_fpath}']/@ID"
-              "${ocrd__argv[mets_file]}" )
-    if ! image_in_id=$(xmlstarlet "${options[@]}"); then
-        echo "WARNING: image URL '${image_in_fpath}' not referenced"\
-             "in METS for input file ID=${in_id} (pageId=${in_pageId})" >&2
-        image_in_id="${in_id}-IMG" # fallback
-    fi
-    
     # set output names
     image_out_id="${image_in_id}-BIN_${params[impl]}"
     image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
@@ -180,7 +230,7 @@ EOF
          "$image_out_fpath"
 
     # Reference image file in PAGE
-    modify_page "$namespace" "$ns_prefix" "$image_out_fpath" "$out_fpath"
+    modify_page "$namespace" "$ns_prefix" "$image_out_fpath" "$out_fpath" "$comments"
     
     return 0
 }
@@ -188,7 +238,6 @@ EOF
 function process_imagefile {
     local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5" image_out_file_grp="$6"
     local image_out_fpath image_out_id
-    local IFS=$' \t\n'
 
     image_out_id="${out_id}-BIN_${params[impl]}"
     image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
@@ -224,7 +273,7 @@ function process_imagefile {
   <Page imageFilename="$in_fpath" imageWidth="$imageWidth" imageHeight="$imageHeight" type="content"/>
 </PcGts>
 EOF
-    modify_page "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" "" "$image_out_fpath" "$out_fpath"
+    modify_page "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" "" "$image_out_fpath" "$out_fpath" "binarized"
 
     return 0
 }
@@ -256,10 +305,12 @@ function main {
                   -k mimetype        \
                   -k pageId          \
                   --download))
+    local IFS=$' \t\n'
     for csv in "${files[@]}"; do
         # Parse comma separated fields
         local IFS=$'\t'
         local fields=($csv)
+        local IFS=$' \t\n'
 
         local in_fpath="${fields[0]}"
         local in_id="${fields[1]}"

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -154,15 +154,15 @@ EOF
 
     # find image file representing the page in METS
     # FIXME: add a bashlib wrapper for constants (METS tags) to use here
-    if ! options=( sel
-                   -N mets=http://www.loc.gov/METS/
-                   -N xlink=http://www.w3.org/1999/xlink
-                   -t -v "//mets:file[starts-with(@MIMETYPE,'image/') and ./mets:FLocat/@xlink:href='${image_in_fpath}']/@ID" 
-                   mets.xml )
-       image_in_id=$(xmlstarlet "${options[@]}"); then
-        echo "ERROR: image URL '${image_in_fpath}' not referenced"\
+    options=( sel
+              -N mets=http://www.loc.gov/METS/
+              -N xlink=http://www.w3.org/1999/xlink
+              -t -v "//mets:file[starts-with(@MIMETYPE,'image/') and ./mets:FLocat/@xlink:href='${image_in_fpath}']/@ID"
+              "${ocrd__argv[mets_file]}" )
+    if ! image_in_id=$(xmlstarlet "${options[@]}"); then
+        echo "WARNING: image URL '${image_in_fpath}' not referenced"\
              "in METS for input file ID=${in_id} (pageId=${in_pageId})" >&2
-        return 1
+        image_in_id="${in_id}-IMG" # fallback
     fi
     
     # set output names

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -24,7 +24,7 @@ set -Eu
 which ocrd >/dev/null 2>/dev/null || { echo "ocrd not in \$PATH. Panicking"; exit 1; }
 
 SHAREDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-IMAGE_FILEGRP="OCR-D-IMG-BIN"
+FALLBACK_IMAGE_FILEGRP="OCR-D-IMG-BIN"
 PRESERVE_NAMESPACE=1
 
 function call_scribo {
@@ -95,7 +95,7 @@ function modify_page {
 }
 
 function process_pagefile {
-    local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5"
+    local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5" image_out_file_grp="$6"
     local image_in_fpath image_in_id image_out_fpath image_out_id
     
     if (($PRESERVE_NAMESPACE)); then
@@ -167,13 +167,13 @@ EOF
     
     # set output names
     image_out_id="${image_in_id}-BIN_${params[impl]}"
-    image_out_fpath="${IMAGE_FILEGRP}/${image_out_id}.png"
+    image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
 
     call_scribo "${params[impl]}" "${image_in_fpath}" "${image_out_fpath}"
     
     # Add image file to METS
     ocrd workspace add        \
-         -G ${IMAGE_FILEGRP}  \
+         -G ${image_out_file_grp}  \
          -g "$in_pageId"      \
          -m image/png         \
          -i "$image_out_id"   \
@@ -186,18 +186,18 @@ EOF
 }
 
 function process_imagefile {
-    local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5"
+    local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5" image_out_file_grp="$6"
     local image_out_fpath image_out_id
     local IFS=$' \t\n'
 
     image_out_id="${out_id}-BIN_${params[impl]}"
-    image_out_fpath="${IMAGE_FILEGRP}/${image_out_id}.png"
+    image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
 
     call_scribo "${params[impl]}" "${in_fpath}" "${image_out_fpath}"
 
     # Add image file to METS
     ocrd workspace add        \
-         -G ${IMAGE_FILEGRP}  \
+         -G ${image_out_file_grp}  \
          -g "$in_pageId"      \
          -m image/png         \
          -i "$image_out_id"   \
@@ -237,7 +237,14 @@ function main {
     cd "${ocrd__argv[working_dir]}"
     in_file_grp=${ocrd__argv[input_file_grp]}
     out_file_grp=${ocrd__argv[output_file_grp]}
-    mkdir -p $out_file_grp
+    page_out_file_grp=${out_file_grp%%,*}
+    image_out_file_grp=${out_file_grp##*,}
+    if [[ x$image_out_file_grp = x$out_file_grp ]];then
+        image_out_file_grp=$FALLBACK_IMAGE_FILEGRP
+        echo >&2 "INFO: No output file group for images specified, falling back to '$image_out_file_grp'"
+    fi
+    mkdir -p $page_out_file_grp
+    mkdir -p $image_out_file_grp
     # FIXME: add a bashlib wrapper for constants (MIMETYPE_PAGE) to use here
     MIMETYPE_PAGE=application/vnd.prima.page+xml
 
@@ -264,13 +271,13 @@ function main {
            continue
         fi 
 
-        local out_id="${in_id//$in_file_grp/$out_file_grp}"
-        local out_fpath="$out_file_grp/${out_id}.xml"
+        local out_id="${in_id//$in_file_grp/$page_out_file_grp}"
+        local out_fpath="$page_out_file_grp/${out_id}.xml"
 
         if [ "x${in_mimetype}" = x${MIMETYPE_PAGE} ]; then
-            process_pagefile "$in_fpath" "$in_id" "$in_pageId" "$out_fpath" "$out_id"
+            process_pagefile "$in_fpath" "$in_id" "$in_pageId" "$out_fpath" "$out_id" "$image_out_file_grp"
         elif [ "${in_mimetype}" != "${in_mimetype#image/}" ]; then
-            process_imagefile "$in_fpath" "$in_id" "$in_pageId" "$out_fpath" "$out_id"
+            process_imagefile "$in_fpath" "$in_id" "$in_pageId" "$out_fpath" "$out_id" "$image_out_file_grp"
         else
             echo "ERROR: input file ID=${in_id} (pageId=${in_pageId} MIME=${in_mimetype}) is neither an image nor a PAGE-XML file" >&2
             continue
@@ -283,7 +290,7 @@ function main {
         else
             options=()
         fi
-        options+=( -G $out_file_grp
+        options+=( -G $page_out_file_grp
                    -m $MIMETYPE_PAGE
                    -i "$out_id"
                    "$out_fpath" )

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -39,18 +39,18 @@ function call_scribo {
 }
 
 function modify_page {
-    local in_namespace="$1" in_prefix="$2" image_out_fpath="$3" out_fpath="$4"
+    local namespace="$1" ns_prefix="$2" image_out_fpath="$3" out_fpath="$4"
 
     local IFS=$' \t\n'
     declare -a options
     options+=( --no-doc-namespace ed --inplace
-               -N pc="${in_namespace}"
+               -N pc="${namespace}"
                # update LastChange date stemp:
                -u '/pc:PcGts/pc:Metadata/pc:LastChange'
                -v "$(date -Iseconds)"
                # insert MetadataItem with runtime parameters:
                -s '/pc:PcGts/pc:Metadata'
-               -t elem -n "${in_prefix}MetadataItem"
+               -t elem -n "${ns_prefix}MetadataItem"
                # bind previous element to "new-item":
                --var new-item '$prev'
                -s '$new-item' -t attr -n type
@@ -75,7 +75,7 @@ function modify_page {
     done
     # insert/append AlternativeImage:
     if xmlstarlet --no-doc-namespace sel              \
-                  -N pc=${in_namespace} --quiet       \
+                  -N pc=${namespace} --quiet       \
                   -t -v '/pc:PcGts/pc:Page/*'         \
                   "$out_fpath"; then
         # something exists: insert before
@@ -84,7 +84,7 @@ function modify_page {
         # nothing here yet: append subnode
         options+=( -s '/pc:PcGts/pc:Page' )
     fi
-    options+=( -t elem -n "${in_prefix}AlternativeImage"
+    options+=( -t elem -n "${ns_prefix}AlternativeImage"
                --var new-image '$prev'
                -s '$new-image' -t attr -n filename
                                -v "$image_out_fpath"
@@ -97,15 +97,6 @@ function modify_page {
 function process_pagefile {
     local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5"
     local image_in_fpath image_in_id image_out_fpath image_out_id
-    
-    # to become independent of whether and what
-    # namespace prefix is used for PAGE-XML,
-    # we first have to know the namespace:
-    in_namespace=$(xmlstarlet sel -t -m '/*[1]' -v 'namespace-uri()' "$in_fpath")
-    # now (using --no-doc-namespace) we can
-    # safely query with -N pc=${in_namespace}
-    # and safely add with prefix ${in_prefix}:
-    in_prefix=$(xmlstarlet sel -t -m '/*[1]' -v 'substring-before(name(),"PcGts")' "$in_fpath")
     
     if (($PRESERVE_NAMESPACE)); then
         # preserve namespace and prefix
@@ -133,10 +124,19 @@ EOF
         xmlstarlet tr convert-namespace.xsl <"$in_fpath" >"$out_fpath"
     fi
 
+    # to become independent of whether and what
+    # namespace prefix is used for PAGE-XML,
+    # we first have to know the namespace:
+    namespace=$(xmlstarlet sel -t -m '/*[1]' -v 'namespace-uri()' "$out_fpath")
+    # now (using --no-doc-namespace) we can
+    # safely query with -N pc=${namespace}
+    # and safely add with prefix ${ns_prefix}:
+    ns_prefix=$(xmlstarlet sel -t -m '/*[1]' -v 'substring-before(name(),"PcGts")' "$out_fpath")
+    
     declare -a options
     # find image file representing the page in PAGE
     if options=( --no-doc-namespace sel
-                 -N pc="${in_namespace}" -t 
+                 -N pc="${namespace}" -t 
                  -v '/pc:PcGts/pc:Page/pc:AlternativeImage[last()]/@filename' 
                  "$out_fpath" )
        image_in_fpath=$(xmlstarlet "${options[@]}"); then
@@ -144,7 +144,7 @@ EOF
              "for input file ID=${in_id} (pageId=${in_pageId})" >&2
     else
         options=( --no-doc-namespace sel
-                  -N pc="${in_namespace}" -t
+                  -N pc="${namespace}" -t
                   -v '/pc:PcGts/pc:Page/@imageFilename'
                   "$out_fpath" )
         image_in_fpath=$(xmlstarlet "${options[@]}")
@@ -180,7 +180,7 @@ EOF
          "$image_out_fpath"
 
     # Reference image file in PAGE
-    modify_page "$in_namespace" "$in_prefix" "$image_out_fpath" "$out_fpath"
+    modify_page "$namespace" "$ns_prefix" "$image_out_fpath" "$out_fpath"
     
     return 0
 }

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -336,7 +336,7 @@ function main {
 
         # Add PAGE file to METS
         declare -a options
-        if [ -z "$in_pageId" ]; then
+        if [ -n "$in_pageId" ]; then
             options=( -g $in_pageId )
         else
             options=()

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -1,28 +1,254 @@
 #!/bin/bash
-set -eu
+set -Eu
 # set -x
+
+### binarization with Olena
+# 
+# Finds and downloads all files in the input fileGrp
+# of the workspace. Then for each file, determines its
+# MIME type: 
+# If PAGE-XML, queries the input file for an existing
+# AlternativeImage on the Page level, otherwise uses
+# imageFilename. Passes the image file to the scribo
+# binarization program for the chosen algorithm. The
+# resulting file will reside in OCR-D-IMG-BIN and its
+# ID will be derived from the input file's ID. Finally,
+# adds a reference to the new file by appending some
+# AlternativeImage to the PAGE-XML.
+# If an image, creates a skeleton PAGE-XML for that
+# imageFilename. Passes the image file to scribo
+# likewise. Also adds a reference to the new file
+# by inserting an AlternativeImage to the PAGE-XML.
+# Regardless, adds new image and new PAGE-XML to METS.
 
 which ocrd >/dev/null 2>/dev/null || { echo "ocrd not in \$PATH. Panicking"; exit 1; }
 
 SHAREDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+IMAGE_FILEGRP="OCR-D-IMG-BIN"
+PRESERVE_NAMESPACE=1
 
-main () {
+function call_scribo {
+    # Binarize as PBM
+    scribo-cli "$1" "$2" "${3}.pbm"
+
+    # Convert PBM to PNG
+    convert "${3}.pbm" -negate "$3"
+
+    # Remove PBM
+    rm "${3}.pbm" 
+}
+
+function modify_page {
+    local in_namespace="$1" in_prefix="$2" image_out_fpath="$3" out_fpath="$4"
+
+    local IFS=$' \t\n'
+    declare -a options
+    options+=( --no-doc-namespace ed --inplace
+               -N pc="${in_namespace}"
+               # update LastChange date stemp:
+               -u '/pc:PcGts/pc:Metadata/pc:LastChange'
+               -v "$(date -Iseconds)"
+               # insert MetadataItem with runtime parameters:
+               -s '/pc:PcGts/pc:Metadata'
+               -t elem -n "${in_prefix}MetadataItem"
+               # bind previous element to "new-item":
+               --var new-item '$prev'
+               -s '$new-item' -t attr -n type
+                              -v "processingStep"
+               -s '$new-item' -t attr -n name
+                              -v "preprocessing/optimization/binarization"
+               -s '$new-item' -t attr -n value
+                              -v "ocrd-olena-binarize"
+               # add "Labels":
+               -s '$new-item' -t elem -n Labels
+               # bind previous element to "new-labels":
+               --var new-labels '$prev' )
+    for key in ${!params[@]}; do
+        options+=( # add another "Label":
+                   -s '$new-labels' -t elem -n Label
+                   # bind previous element to "new-label":
+                   --var new-label '$prev'
+                   -s '$new-label' -t attr -n value
+                                   -v ${params[$key]}
+                   -s '$new-label' -t attr -n type
+                                   -v $key )
+    done
+    # insert/append AlternativeImage:
+    if xmlstarlet --no-doc-namespace sel              \
+                  -N pc=${in_namespace} --quiet       \
+                  -t -v '/pc:PcGts/pc:Page/*'         \
+                  "$out_fpath"; then
+        # something exists: insert before
+        options+=( -i '/pc:PcGts/pc:Page/*[1]' )
+    else
+        # nothing here yet: append subnode
+        options+=( -s '/pc:PcGts/pc:Page' )
+    fi
+    options+=( -t elem -n "${in_prefix}AlternativeImage"
+               --var new-image '$prev'
+               -s '$new-image' -t attr -n filename
+                               -v "$image_out_fpath"
+               -s '$new-image' -t attr -n comments
+                               -v "binarized"
+                               "$out_fpath" )
+    xmlstarlet "${options[@]}"
+}
+
+function process_pagefile {
+    local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5"
+    local image_in_fpath image_in_id image_out_fpath image_out_id
+    
+    # to become independent of whether and what
+    # namespace prefix is used for PAGE-XML,
+    # we first have to know the namespace:
+    in_namespace=$(xmlstarlet sel -t -m '/*[1]' -v 'namespace-uri()' "$in_fpath")
+    # now (using --no-doc-namespace) we can
+    # safely query with -N pc=${in_namespace}
+    # and safely add with prefix ${in_prefix}:
+    in_prefix=$(xmlstarlet sel -t -m '/*[1]' -v 'substring-before(name(),"PcGts")' "$in_fpath")
+    
+    if (($PRESERVE_NAMESPACE)); then
+        # preserve namespace and prefix
+        cat <"$in_fpath" >"$out_fpath"
+    else
+        # stylesheet transforms to standard namespace:
+        # FIXME: add a bashlib wrapper for constants (page NAMESPACE) to use here
+        cat <<"EOF" >convert-namespace.xsl
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<xsl:stylesheet version="1.0"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+  xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15">
+  <xsl:output method="xml" version="1.0" 
+    encoding="UTF-8" indent="yes"/>
+  <xsl:template match="@*|text()|comment()|processing-instruction()">
+    <xsl:copy/>
+  </xsl:template>
+  <xsl:template match="*">
+    <xsl:element name="{local-name()}">
+      <xsl:apply-templates select="@*|*"/>
+    </xsl:element>
+  </xsl:template>
+</xsl:stylesheet>
+EOF
+        xmlstarlet tr convert-namespace.xsl <"$in_fpath" >"$out_fpath"
+    fi
+
+    declare -a options
+    # find image file representing the page in PAGE
+    if options=( --no-doc-namespace sel
+                 -N pc="${in_namespace}" -t 
+                 -v '/pc:PcGts/pc:Page/pc:AlternativeImage[last()]/@filename' 
+                 "$out_fpath" )
+       image_in_fpath=$(xmlstarlet "${options[@]}"); then
+        echo "INFO: found AlternativeImage filename '${image_in_fpath}'"\
+             "for input file ID=${in_id} (pageId=${in_pageId})" >&2
+    else
+        options=( --no-doc-namespace sel
+                  -N pc="${in_namespace}" -t
+                  -v '/pc:PcGts/pc:Page/@imageFilename'
+                  "$out_fpath" )
+        image_in_fpath=$(xmlstarlet "${options[@]}")
+        echo "INFO: found imageFilename '${image_in_fpath}'"\
+             "for input file ID=${in_id} (pageId=${in_pageId})" >&2
+    fi
+
+    # find image file representing the page in METS
+    # FIXME: add a bashlib wrapper for constants (METS tags) to use here
+    if ! options=( sel
+                   -N mets=http://www.loc.gov/METS/
+                   -N xlink=http://www.w3.org/1999/xlink
+                   -t -v "//mets:file[starts-with(@MIMETYPE,'image/') and ./mets:FLocat/@xlink:href='${image_in_fpath}']/@ID" 
+                   mets.xml )
+       image_in_id=$(xmlstarlet "${options[@]}"); then
+        echo "ERROR: image URL '${image_in_fpath}' not referenced"\
+             "in METS for input file ID=${in_id} (pageId=${in_pageId})" >&2
+        return 1
+    fi
+    
+    # set output names
+    image_out_id="${image_in_id}-BIN_${params[impl]}"
+    image_out_fpath="${IMAGE_FILEGRP}/${image_out_id}.png"
+
+    call_scribo "${params[impl]}" "${image_in_fpath}" "${image_out_fpath}"
+    
+    # Add image file to METS
+    ocrd workspace add        \
+         -G ${IMAGE_FILEGRP}  \
+         -g "$in_pageId"      \
+         -m image/png         \
+         -i "$image_out_id"   \
+         "$image_out_fpath"
+
+    # Reference image file in PAGE
+    modify_page "$in_namespace" "$in_prefix" "$image_out_fpath" "$out_fpath"
+    
+    return 0
+}
+
+function process_imagefile {
+    local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5"
+    local image_out_fpath image_out_id
+    local IFS=$' \t\n'
+
+    image_out_id="${out_id}-BIN_${params[impl]}"
+    image_out_fpath="${IMAGE_FILEGRP}/${image_out_id}.png"
+
+    call_scribo "${params[impl]}" "${in_fpath}" "${image_out_fpath}"
+
+    # Add image file to METS
+    ocrd workspace add        \
+         -G ${IMAGE_FILEGRP}  \
+         -g "$in_pageId"      \
+         -m image/png         \
+         -i "$image_out_id"   \
+         "$image_out_fpath"
+
+    # Reference image file in PAGE
+    # FIXME: add a bashlib wrapper for OcrdExif to use here
+    imageInfo=($(identify "$in_fpath"))
+    imageGeometry=${imageInfo[2]}
+    imageWidth=${imageGeometry%x*}
+    imageHeight=${imageGeometry#*x}
+    # FIXME: add a bashlib wrapper for page_from_file to use here
+    cat <<EOF > "$out_fpath"
+<?xml version="1.0" encoding="UTF-8"?>
+<PcGts xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
+  xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd">
+  <Metadata>
+    <Creator>OCR-D/core $(versionstring=($(ocrd --version)); echo ${versionstring[-1]})</Creator>
+    <Created>$(date -Iseconds)</Created>
+    <LastChange/>
+  </Metadata>
+  <Page imageFilename="$in_fpath" imageWidth="$imageWidth" imageHeight="$imageHeight" type="content"/>
+</PcGts>
+EOF
+    modify_page "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" "" "$image_out_fpath" "$out_fpath"
+
+    return 0
+}
+    
+function main {
     source `ocrd bashlib filename`
     ocrd__wrap "$SHAREDIR/ocrd-tool.json" "ocrd-olena-binarize" "$@"
+    # FIXME: add a bashlib wrapper for logging to use here
 
     cd "${ocrd__argv[working_dir]}"
     in_file_grp=${ocrd__argv[input_file_grp]}
     out_file_grp=${ocrd__argv[output_file_grp]}
     mkdir -p $out_file_grp
+    # FIXME: add a bashlib wrapper for constants (MIMETYPE_PAGE) to use here
+    MIMETYPE_PAGE=application/vnd.prima.page+xml
 
     local IFS=$'\n'
     files=($(ocrd workspace find     \
-        -G $in_file_grp              \
-        -k local_filename            \
-        -k ID                        \
-        -k mimetype                  \
-        -k pageId                    \
-        --download))
+                  -G $in_file_grp    \
+                  -k local_filename  \
+                  -k ID              \
+                  -k mimetype        \
+                  -k pageId          \
+                  --download))
     for csv in "${files[@]}"; do
         # Parse comma separated fields
         local IFS=$'\t'
@@ -33,33 +259,35 @@ main () {
         local in_mimetype="${fields[2]}"
         local in_pageId="${fields[3]:-}"
 
-        local out_id="${in_id//$in_file_grp/$out_file_grp}-${params[impl]}"
-        local out_fpath="$out_file_grp/${out_id}.png"
+        if ! test -f "$in_fpath"; then
+           echo "ERROR: input file ID=${in_id} (pageId=${in_pageId} MIME=${in_mimetype}) is not on disk" >&2
+           continue
+        fi 
 
-        # Binarize as PBM
-        scribo-cli "${params[impl]}" "$in_fpath" "$out_fpath.pbm"
+        local out_id="${in_id//$in_file_grp/$out_file_grp}"
+        local out_fpath="$out_file_grp/${out_id}.xml"
 
-        # Convert PBM to PNG
-        convert "$out_fpath.pbm" -negate "$out_fpath"
-
-        # Remove PBM
-        rm "$out_fpath.pbm" 
-
-        # Add files
-        if test -z "$in_pageId"; then
-        ocrd workspace add   \
-            -G $out_file_grp \
-            -m image/png     \
-            -i "$out_id"     \
-            "$out_fpath"
+        if [ "x${in_mimetype}" = x${MIMETYPE_PAGE} ]; then
+            process_pagefile "$in_fpath" "$in_id" "$in_pageId" "$out_fpath" "$out_id"
+        elif [ "${in_mimetype}" != "${in_mimetype#image/}" ]; then
+            process_imagefile "$in_fpath" "$in_id" "$in_pageId" "$out_fpath" "$out_id"
         else
-        ocrd workspace add   \
-            -G $out_file_grp \
-            -g $in_pageId    \
-            -m image/png     \
-            -i "$out_id"     \
-            "$out_fpath"
+            echo "ERROR: input file ID=${in_id} (pageId=${in_pageId} MIME=${in_mimetype}) is neither an image nor a PAGE-XML file" >&2
+            continue
         fi
+
+        # Add PAGE file to METS
+        declare -a options
+        if [ -z "$in_pageId" ]; then
+            options=( -g $in_pageId )
+        else
+            options=()
+        fi
+        options+=( -G $out_file_grp
+                   -m $MIMETYPE_PAGE
+                   -i "$out_id"
+                   "$out_fpath" )
+        ocrd workspace add "${options[@]}"
     done
 }
 

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -Eu
+set -eu
 # set -x
 
 ### binarization with Olena
@@ -170,7 +170,7 @@ EOF
     # now (using --no-doc-namespace) we can
     # safely query with -N pc=${namespace}
     # and safely add with prefix ${ns_prefix}:
-    ns_prefix=$(xmlstarlet sel -t -m '/*[1]' -v 'substring-before(name(),"PcGts")' "$out_fpath")
+    ns_prefix=$(xmlstarlet sel -t -m '/*[1]' -v 'substring-before(name(),"PcGts")' "$out_fpath"; true)
     
     declare -a options
     # find image file representing the page in PAGE

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -288,7 +288,7 @@ function main {
     out_file_grp=${ocrd__argv[output_file_grp]}
     page_out_file_grp=${out_file_grp%%,*}
     image_out_file_grp=${out_file_grp##*,}
-    if [[ x$image_out_file_grp = x$out_file_grp ]];then
+    if [ x$image_out_file_grp = x$out_file_grp ];then
         image_out_file_grp=$FALLBACK_IMAGE_FILEGRP
         echo >&2 "INFO: No output file group for images specified, falling back to '$image_out_file_grp'"
     fi
@@ -306,7 +306,9 @@ function main {
                   -k pageId          \
                   --download))
     local IFS=$' \t\n'
+    local n=0 zeros=0000
     for csv in "${files[@]}"; do
+        let n+=1
         # Parse comma separated fields
         local IFS=$'\t'
         local fields=($csv)
@@ -323,6 +325,9 @@ function main {
         fi 
 
         local out_id="${in_id//$in_file_grp/$page_out_file_grp}"
+        if [ "x$out_id" = "x$in_id" ]; then
+            out_id=${page_out_file_grp}_${zeros:0:$((4-${#n}))}$n
+        fi
         local out_fpath="$page_out_file_grp/${out_id}.xml"
 
         if [ "x${in_mimetype}" = x${MIMETYPE_PAGE} ]; then

--- a/ocrd-tool.json
+++ b/ocrd-tool.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.0.1",
-  "git_url": "https://github.com/OCR-D/ocrd_ocrevaluation",
+  "version": "0.0.2",
+  "git_url": "https://github.com/OCR-D/ocrd_olena",
   "tools": {
     "ocrd-olena-binarize": {
       "executable": "ocrd-olena-binarize",
@@ -12,10 +12,15 @@
         "preprocessing/optimization/binarization"
       ],
       "input_file_grp": [
+        "OCR-D-SEG-BLOCK",
+        "OCR-D-SEG-LINE",
+        "OCR-D-SEG-WORD",
         "OCR-D-IMG"
       ],
       "output_file_grp": [
-        "OCR-D-IMG-BIN"
+        "OCR-D-SEG-BLOCK",
+        "OCR-D-SEG-LINE",
+        "OCR-D-SEG-WORD"
       ],
       "parameters": {
         "impl": {

--- a/test/test.sh
+++ b/test/test.sh
@@ -4,9 +4,12 @@ export PATH="$PWD/..:$PWD/../local/bin:$PATH"
 export assets="$PWD/assets"
 export workspace_dir="/tmp/test-ocrd-olena-binarize"
 
+echo >&2 "Testing image input / PAGE+image output"
+
 # Init workspace
 rm -rf "$workspace_dir"
 ocrd workspace clone -a "$assets/scribo-test/data/mets.xml" "$workspace_dir"
+# workaround for OCR-D/core#96:
 cp -rt "$workspace_dir" "$assets/scribo-test/data/OCR-D-IMG" 
 
 declare -a algos=(sauvola sauvola-ms-fg sauvola-ms sauvola-ms-split)
@@ -15,17 +18,84 @@ for algo in "${algos[@]}";do
     ocrd-olena-binarize \
         -m "$workspace_dir"/mets.xml \
         -I OCR-D-IMG \
-        -O "OCR-D-SEG-NONE-${algo},OCR-D-IMG-BIN-${algo}" \
+        -O "OCR-D-SEG-PAGE-${algo},OCR-D-IMG-BIN-${algo}" \
         -p <(echo '{"impl": "'$algo'"}')
 done
 
 for algo in "${algos[@]}";do
-    echo >&2 "# Diffing $algo"
+    echo >&2 "# Diffing $algo image binary size"
     should=$(wc -c "$workspace_dir"/OCR-D-IMG-BIN-${algo}/*.png | grep -o '^[0-9]*')
     actual=$(wc -c "$assets"/scribo-test/data/OCR-D-IMG-BIN-${algo^^}/* | grep -o '^[0-9]*')
     if [[ $should != $actual ]];then
         echo "not ok - $algo: Expected $should but is $actual"
+        false
     else
         echo "ok - $algo: Matches $should == $actual"
     fi
+    echo >&2 "# Checking $algo PAGE result"
+    # roughly check output fileGrp and comments:
+    if grep -q "AlternativeImage filename=\"OCR-D-IMG-BIN-${algo}/[^\"]*\" comments=\"binarized\"" "$workspace_dir"/OCR-D-SEG-PAGE-${algo}/*.xml; then
+        echo "ok - $algo: binarized AlternativeImage in PAGE result"
+    else
+        echo "not ok - $algo: no binarized AlternativeImage in PAGE result"
+        false
+    fi
+done
+
+echo >&2 "Testing PAGE+image input / PAGE+image output"
+
+# Init workspace
+rm -rf "$workspace_dir"
+ocrd workspace clone -a "$assets/kant_aufklaerung_1784/data/mets.xml" "$workspace_dir"
+# workaround for OCR-D/core#96:
+cp -rt "$workspace_dir" "$assets"/kant_aufklaerung_1784/data/{OCR-D-IMG,OCR-D-GT-PAGE}
+# workaround for OCR-D/core#176:
+for file in "$workspace_dir"/OCR-D-GT-PAGE/*; do
+    sed -i 's,imageFilename="https://github.com/OCR-D/assets/raw/master/data/kant_aufklaerung_1784/data/,imageFilename=",' "$file"
+done
+
+declare -a algos=(sauvola wolf)
+for algo in "${algos[@]}";do
+    echo >&2 "# Generating $algo"
+    ocrd-olena-binarize \
+        -m "$workspace_dir"/mets.xml \
+        -I OCR-D-GT-PAGE \
+        -O "OCR-D-SEG-PAGE-${algo},OCR-D-IMG-BIN" \
+        -p <(echo '{"impl": "'$algo'"}')
+done
+
+for algo in "${algos[@]}";do
+    declare -A original_images binarized_images binarized_pages
+    while read pageId local_filename; do
+        original_images[$pageId]="$local_filename"
+    done < <(ocrd workspace -d "$workspace_dir" find -k pageId -k local_filename | fgrep -e OCR-D-IMG/)
+    while read pageId local_filename; do
+        binarized_pages[$pageId]="$local_filename"
+    done < <(ocrd workspace -d "$workspace_dir" find -k pageId -k local_filename | fgrep -e OCR-D-SEG-PAGE-${algo}/)
+    for pageId in ${!original_images[@]}; do
+        original_image=${original_images[$pageId]}
+        binarized_page=${binarized_pages[$pageId]}
+        echo >&2 "# Checking $algo PAGE result"
+        if binarized_image=$(sed -ne 's|^.*AlternativeImage filename="\(OCR-D-IMG-BIN/[^"]*\)" comments="cropped,binarized".*$|\1|p' "$workspace_dir/$binarized_page"); then
+            echo "ok - $algo $pageId: cropped,binarized AlternativeImage in PAGE result"
+        else
+            echo "not ok - $algo $pageId: no cropped,binarized AlternativeImage in PAGE result"
+            false
+        fi
+        echo >&2 "# Checking $algo image pixel size"
+        original_info=($(identify "$workspace_dir/$original_image"))
+        binarized_info=($(identify "$workspace_dir/$binarized_image"))
+        original_geometry=${original_info[2]}
+        binarized_geometry=${binarized_info[2]}
+        original_width=${original_geometry%x*}
+        original_height=${original_geometry#*x}
+        binarized_width=${binarized_geometry%x*}
+        binarized_height=${binarized_geometry#*x}
+        if [ $original_width -gt $binarized_width -a $original_height -gt $binarized_height ];then
+            echo "ok - $algo $pageId: Cropped $original_geometry to $binarized_geometry"
+        else
+            echo "not ok - $algo $pageId: Expected $original_geometry larger than $binarized_geometry"
+            false
+        fi
+    done
 done

--- a/test/test.sh
+++ b/test/test.sh
@@ -15,7 +15,7 @@ for algo in "${algos[@]}";do
     ocrd-olena-binarize \
         -m "$workspace_dir"/mets.xml \
         -I OCR-D-IMG \
-        -O "OCR-D-IMG-BIN-${algo}" \
+        -O "OCR-D-SEG-NONE-${algo},OCR-D-IMG-BIN-${algo}" \
         -p <(echo '{"impl": "'$algo'"}')
 done
 


### PR DESCRIPTION
- detect whether input file was image/* or PAGE-XML
- for image file, also generate a skeleton PAGE-XML
  (with AlternativeImage for the binarized result)
- for PAGE-XML file, detect namespace (and prefix),
  then check whether AlternativeImage already exists
  or find imageFilename (both on disk and as METS ID),
  process image and add AlternativeImage for result
- reference all new files (image under OCR-D-IMG-BIN,
  PAGE-XML under output fileGrp) in METS
- encapsulate, add pointers for improvement of bashlib
  in core
- improve documentation