### PR TITLE
overwrite image file IDs if necessary

### DIFF
--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -224,6 +224,7 @@ EOF
     
     # Add image file to METS
     ocrd workspace add        \
+         --force              \
          -G ${image_out_file_grp}  \
          -g "$in_pageId"      \
          -m image/png         \
@@ -247,6 +248,7 @@ function process_imagefile {
 
     # Add image file to METS
     ocrd workspace add        \
+         --force              \
          -G ${image_out_file_grp}  \
          -g "$in_pageId"      \
          -m image/png         \


### PR DESCRIPTION
ratio: the processors that use core's `workspace.add_image_file()` in Python all _also_ use this option. And these file IDs do not get removed when the PAGE file group referencing them is removed. Removing the image file group itself however might break other PAGE file groups referencing it (with other IDs from different binarization settings or hierarchy levels).