### PR TITLE
add 2 docker builds: pure scribo and OCR-D binarization wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,15 +16,9 @@ COPY ocrd-tool.json .
 COPY ocrd-olena-binarize .
 COPY README.md /
 
-# ocrd/core is now based on ubuntu:19.10 ...
-# ... Ubuntu 19 ships automake 1.16.2 (and does not package automake-1.15 correctly)
-# ... Ubuntu 19 ships GCC 9 by default (but we need g++-7)
 RUN apt-get update && \
-    apt-get -y install --no-install-recommends build-essential automake-1.15 g++-7 git && \
+    apt-get -y install --no-install-recommends build-essential automake git && \
     make deps-ubuntu && \
-    update-alternatives --set automake /usr/bin/automake-1.15 && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 -5 --slave /usr/bin/g++ g++ /usr/bin/g++-7 && \
-    update-alternatives --set gcc /usr/bin/gcc-7 && \
     make build-olena install clean-olena && \
     apt-get -y remove build-essential git && \
     apt-get -y autoremove && apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Patch and build Olena from Git, then
+# Install OCR-D wrapper for binarization
+FROM ocrd/core
+
+MAINTAINER OCR-D
+
+ENV PREFIX=/usr
+
+WORKDIR /build-olena
+COPY olena-configure-boost.patch .
+COPY olena-configure-python3.patch .
+COPY olena-disable-doc.patch .
+COPY olena-fix-magick-load-catch-exceptions.patch .
+COPY Makefile .
+COPY ocrd-tool.json .
+COPY ocrd-olena-binarize .
+COPY README.md /
+
+# ocrd/core is now based on ubuntu:19.10 ...
+# ... Ubuntu 19 ships automake 1.16.2 (and does not package automake-1.15 correctly)
+# ... Ubuntu 19 ships GCC 9 by default (but we need g++-7)
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends build-essential automake-1.15 g++-7 git && \
+    make deps-ubuntu && \
+    update-alternatives --set automake /usr/bin/automake-1.15 && \
+    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 -5 --slave /usr/bin/g++ g++ /usr/bin/g++-7 && \
+    update-alternatives --set gcc /usr/bin/gcc-7 && \
+    make build-olena install clean-olena && \
+    apt-get -y remove build-essential git && \
+    apt-get -y autoremove && apt-get clean && \
+    rm -fr /build-olena
+
+WORKDIR /data
+VOLUME /data
+
+#ENTRYPOINT ["/usr/bin/ocrd-olena-binarize"]
+#CMD ["--help"]
+CMD ["/usr/bin/ocrd-olena-binarize", "--help"]

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHAREDIR = $(PREFIX)/share/ocrd_olena
 PYTHON ?= $(shell which python3)
 PIP ?= $(shell which pip3)
 
+DOCKER_TAG ?= ocrd/olena
 TOOLS = $(shell ocrd ocrd-tool ocrd-tool.json list-tools)
 
 # BEGIN-EVAL makefile-parser --make-help Makefile
@@ -19,6 +20,7 @@ help:
 	@echo "    assets       Setup test assets"
 	@echo "    test         Run basic tests"
 	@echo "    clean        Uninstall, then remove assets and build"
+	@echo "    docker       Build docker images"
 	@echo ""
 	@echo "  Variables"
 	@echo ""
@@ -56,8 +58,8 @@ endif
 	cd $(OLENA_DIR) && autoreconf -i
 
 deps-ubuntu:
-	apt install libmagick++-dev libgraphicsmagick++1-dev libboost-dev \
-		xmlstarlet
+	apt-get -y install libmagick++-dev libgraphicsmagick++1-dev libboost-dev \
+		xmlstarlet ca-certificates
 
 deps: #deps-ubuntu
 	test -x $(BINDIR)/scribo-cli && \
@@ -137,7 +139,11 @@ clean:
 	$(MAKE) clean-olena
 	$(RM) -r test/assets
 
-.PHONY: build-olena clean-olena deps deps-ubuntu help install test clean
+docker: build-olena.dockerfile Dockerfile
+	docker build -t $(DOCKER_TAG):build-olena -f build-olena.dockerfile .
+	docker build -t $(DOCKER_TAG) .
+
+.PHONY: build-olena clean-olena deps deps-ubuntu help install test clean docker
 
 # do not search for implicit rules here:
 Makefile: ;

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # ocrd_olena
 
-> Bundle olena as an OCR-D tool
+> Binarize with Olena/scribo
 
 [![Build Status](https://travis-ci.org/OCR-D/ocrd_olena.svg?branch=master)](https://travis-ci.org/OCR-D/ocrd_olena)
+[![Docker Automated build](https://img.shields.io/docker/automated/ocrd/core.svg)](https://hub.docker.com/r/ocrd/olena/tags/)
 
 ## Requirements
 
@@ -10,15 +11,21 @@
 make deps-ubuntu
 ```
 
-...will try to install the required packages on Ubuntu.
+...will try to install the required packages on Ubuntu 18.04. (Newer releases or other systems based on `automake>1.15` and `GCC>7` will need adjustments.)
 
 ## Installation
+
+```
+make build-olena
+```
+
+...will download, patch and build Olena/scribo from source, and install locally (in VIRTUAL_ENV or in CWD/local).
 
 ```
 make install
 ```
 
-...will download, patch and build olena/scribo from source, and install locally (in a path relative to the CWD).
+...will do that, but additionally install `ocrd-binarize-olena` (the OCR-D wrapper).
 
 ## Testing
 
@@ -32,9 +39,71 @@ make test
 
 This package has the following user interfaces:
 
-### [OCR-D processor](https://github.com/OCR-D/core) interface `ocrd-olena-binarize`
+### command line interface `scribo-cli`
 
-To be used with [PageXML](https://www.primaresearch.org/tools/PAGELibraries) documents in an [OCR-D](https://github.com/OCR-D/spec/) annotation workflow. Input could be any valid workspace with source images available. Currently covers the `Page` hierarchy level only. Uses either (the last) `AlternativeImage`, if any, or `imageFilename`, otherwise. Adds an `AlternativeImage` with the result of binarization for every page.
+Converts images in any format to netpbm (monochrome portable bitmap).
+
+```
+Usage: scribo-cli [version] [help] COMMAND [ARGS]
+
+List of available COMMAND argument:
+
+  Full Toolchains
+  ---------------
+
+
+   * On documents
+
+     doc-ppc	       Common preprocessing before looking for text.
+
+     doc-ocr           Find and recognize text. Output: the actual text
+     		       and its location.
+
+     doc-dia           Analyse the document structure and extract the
+     		       text. Output: an XML file with region and text
+     		       information.
+
+
+
+   * On pictures
+
+     pic-loc           Try to localize text if there's any.
+
+     pic-ocr           Localize and try to recognize text.
+
+
+
+  Tools
+  -----
+
+
+     * xml2doc	       Convert the XML results of document toolchains
+       		       into user documents (HTML, PDF...).
+
+
+  Algorithms
+  ----------
+
+
+   * Binarization
+
+     sauvola           Sauvola's algorithm.
+
+     sauvola-ms        Multi-scale Sauvola's algorithm.
+
+     sauvola-ms-fg     Extract foreground objects and run multi-scale
+                       Sauvola's algorithm.
+
+     sauvola-ms-split  Run multi-scale Sauvola's algorithm on each color
+                       component and merge results.
+
+---------------------------------------------------------------------------
+See 'scribo-cli COMMAND --help' for more information on a specific command.
+```
+
+### [OCR-D processor](https://ocr-d.github.com/cli) interface `ocrd-olena-binarize`
+
+To be used with [PageXML](https://github.com/PRImA-Research-Lab/PAGE-XML) documents in an [OCR-D](https://ocr-d.github.io) annotation workflow. Input could be any valid workspace with source images available. Currently covers the `Page` hierarchy level only. Uses either (the last) `AlternativeImage`, if any, or `imageFilename`, otherwise. Adds an `AlternativeImage` with the result of binarization for every page.
 
 ```json
     "ocrd-olena-binarize": {

--- a/build-olena.dockerfile
+++ b/build-olena.dockerfile
@@ -1,0 +1,28 @@
+# Patch and build Olena from Git
+FROM ubuntu:18.04
+
+MAINTAINER OCR-D
+
+ENV PREFIX=/usr
+
+WORKDIR /build-olena
+COPY olena-configure-boost.patch .
+COPY olena-configure-python3.patch .
+COPY olena-disable-doc.patch .
+COPY olena-fix-magick-load-catch-exceptions.patch .
+COPY Makefile .
+
+RUN apt-get update && \
+    apt-get -y install --no-install-recommends build-essential automake git && \
+    make deps-ubuntu && \
+    make build-olena clean-olena && \
+    apt-get -y remove build-essential git && \
+    apt-get -y autoremove && apt-get clean && \
+    rm -fr /build-olena
+
+WORKDIR /data
+VOLUME /data
+
+#ENTRYPOINT ["/usr/bin/scribo-cli"]
+#CMD ["--help"]
+CMD ["/usr/bin/scribo-cli", "--help"]


### PR DESCRIPTION
@kba You should be able to create 2 images and publish under `ocrd` namespace on docker hub by running:
```sh
make docker
docker push ocrd/olena:build-olena
docker push ocrd/olena
```

The first is directly based on Ubuntu 18.04 to make minimal scribo builds (without OCR-D) available to others. The second is based on `ocrd/core`, and therefore needs some workarounds for the Ubuntu 19.10 [problems](OCR-D/core#344). (If you decide to downgrade again, it will suffice to replace the `RUN` command in `Dockerfile` with the one from `build-olena.dockerfile`, except of course for the `install` target which distinguishes both.)
