### PR TITLE
Suppress error when ocrd is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTHON ?= $(shell which python3)
 PIP ?= $(shell which pip3)
 
 DOCKER_TAG ?= ocrd/olena
-TOOLS = $(shell ocrd ocrd-tool ocrd-tool.json list-tools)
+TOOLS = $(shell ocrd ocrd-tool ocrd-tool.json list-tools 2>/dev/null)
 
 # BEGIN-EVAL makefile-parser --make-help Makefile
 


### PR DESCRIPTION
This helps when running `make deps-ubuntu`.

Signed-off-by: Stefan Weil <sw@weilnetz.de>