### PR TITLE
disable tesseract bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,7 @@ $(OLENA_DIR)/build/config.status: $(OLENA_DIR)
 		../configure \
 			--prefix=$(PREFIX) \
 			--disable-dependency-tracking \
+			--with-tesseract=no \
 			--enable-scribo SCRIBO_CXXFLAGS="-DNDEBUG -DSCRIBO_NDEBUG -O2"
 
 build-olena: $(OLENA_DIR)/build/config.status


### PR DESCRIPTION
We have no use-case for Tesseract integration in OCR-D I believe. Plus, IIUC Olena only uses the old, libtesseract3 interface.

The real reason is OCR-D/ocrd_all#15, though.