### PR TITLE
scribo binarization: negate and convert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
 install:
   - sudo apt update
   - sudo make deps-ubuntu
+  - sudo apt-get install imagemagick
   - make deps
   - export PATH="$PWD/local/bin:$PATH"
 script:

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ deps: #deps-ubuntu
 	$(BINDIR)/scribo-cli sauvola --help >/dev/null 2>&1 || \
 		$(MAKE) build-olena
 	which ocrd >/dev/null 2>&1 || \
-		$(PIP) install --pre ocrd # needed for ocrd CLI (and bashlib)
+		$(PIP) install ocrd # needed for ocrd CLI (and bashlib)
 
 # Install
 install: deps
@@ -93,6 +93,7 @@ endif
 uninstall:
 	-$(RM) $(SHAREDIR)/ocrd-tool.json
 	-$(RM) $(TOOLS:%=$(BINDIR)/%)
+	-$(RM) $(BINDIR)/scribo-cli
 	-$(MAKE) -C $(OLENA_DIR)/build uninstall
 
 # Build olena with scribo (document analysis) and swilena (Python bindings)
@@ -139,7 +140,7 @@ test/assets: repo/assets
 
 # Run tests
 test: test/assets install
-	cd test && bash test.sh
+	cd test && PATH=$(BINDIR):$$PATH bash test.sh
 
 clean:
 	$(MAKE) uninstall

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ $(OLENA_TARBALL):
 
 $(OLENA_DIR): olena-configure-python3.patch
 $(OLENA_DIR): olena-disable-doc.patch
+$(OLENA_DIR): olena-add-bin-negate-toggles.patch
 ifeq ($(OLENA_VERSION),git)
 $(OLENA_DIR):
 	git clone https://gitlab.lrde.epita.fr/olena/olena.git $@

--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ List of available COMMAND argument:
 See 'scribo-cli COMMAND --help' for more information on a specific command.
 ```
 
+For example:
+
+```sh
+scribo-cli sauvola-ms path/to/input.tif path/to/output.png --enable-negate-output
+```
+
 ### [OCR-D processor](https://ocr-d.github.com/cli) interface `ocrd-olena-binarize`
 
 To be used with [PageXML](https://github.com/PRImA-Research-Lab/PAGE-XML) documents in an [OCR-D](https://ocr-d.github.io) annotation workflow. Input could be any valid workspace with source images available. Currently covers the `Page` hierarchy level only. Uses either (the last) `AlternativeImage`, if any, or `imageFilename`, otherwise. Adds an `AlternativeImage` with the result of binarization for every page.

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -123,6 +123,12 @@ function modify_page {
     # insert/append AlternativeImage:
     if xmlstarlet --no-doc-namespace sel              \
                   -N "pc=${namespace}" --quiet       \
+                  -t -v '/pc:PcGts/pc:Page/pc:AlternativeImage' \
+                  "$out_fpath"; then
+        # AlternativeImage exists: append after
+        options+=( -a '/pc:PcGts/pc:Page/pc:AlternativeImage[last()]' )
+    elif xmlstarlet --no-doc-namespace sel              \
+                  -N "pc=${namespace}" --quiet       \
                   -t -v '/pc:PcGts/pc:Page/*'         \
                   "$out_fpath"; then
         # something exists: insert before

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -28,21 +28,6 @@ SHAREDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 FALLBACK_IMAGE_FILEGRP="OCR-D-IMG-BIN"
 PRESERVE_NAMESPACE=1
 
-function call_scribo {
-    # Binarize as PBM
-    scribo-cli "$1" "$2" "${3}.pbm"
-
-    # Convert PBM to PNG
-    convert "${3}.pbm" -negate "$3"
-
-    # Remove PBM
-    rm "${3}.pbm"
-
-    if [[ $(basename "$2") =~ ocrd-olena-binarize-cropped.* ]]; then
-        rm "$2"
-    fi
-}
-
 function xywh_from_points {
     # FIXME: add a bashlib wrapper for utils (coordinate conversion) to use here
     minx=$((2**32))
@@ -224,7 +209,7 @@ EOF
     image_out_id="${image_in_id}-BIN_${params[impl]}"
     image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
 
-    call_scribo "${params[impl]}" "${image_in_fpath}" "${image_out_fpath}"
+    scribo-cli "${params[impl]}" "${image_in_fpath}" "${image_out_fpath}" --enable-negate-output
     
     # Add image file to METS
     ocrd workspace add        \
@@ -248,7 +233,7 @@ function process_imagefile {
     image_out_id="${out_id}-BIN_${params[impl]}"
     image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
 
-    call_scribo "${params[impl]}" "${in_fpath}" "${image_out_fpath}"
+    scribo-cli "${params[impl]}" "${in_fpath}" "${image_out_fpath}" --enable-negate-output
 
     # Add image file to METS
     ocrd workspace add        \

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -233,7 +233,25 @@ function process_imagefile {
     image_out_id="${out_id}-BIN_${params[impl]}"
     image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
 
-    scribo-cli "${params[impl]}" "${in_fpath}" "${image_out_fpath}" --enable-negate-output
+    scribo_options=(--enable-negate-output)
+    case ${params[impl]} in
+        otsu)
+            : # has no options whatsoever
+            ;;
+        niblack)
+            scribo_options+=(--disable-negate-input)
+            ;& # fall through
+        sauvola|kim|wolf|singh)
+            scribo_options+=(--k ${params[k]})
+            ;;& # get more
+        sauvola-ms*)
+            scribo_options+=(--all-k ${params[k]})
+            ;;& # get more
+        *)
+            scribo_options+=(--win-size ${params[win-size]})
+            ;;
+    esac
+    scribo-cli "${params[impl]}" "${in_fpath}" "${image_out_fpath}" "${scribo_options[@]}"
 
     # Add image file to METS
     ocrd workspace add        \

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -1,4 +1,6 @@
 #!/bin/bash
+# shellcheck disable=SC2086
+
 set -eu
 set -o pipefail
 # set -x
@@ -28,6 +30,21 @@ SHAREDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 FALLBACK_IMAGE_FILEGRP="OCR-D-IMG-BIN"
 PRESERVE_NAMESPACE=1
 
+MIMETYPE_PAGE=$(ocrd bashlib constants MIMETYPE_PAGE)
+declare -A NAMESPACES
+eval "NAMESPACES=( $(ocrd bashlib constants NAMESPACES) )"
+
+# FIXME: add a bashlib wrapper for logging to use here
+function log {
+    echo >&2 "$(date +%T.%3N) $LEVEL ocrd-olena-binarize - $1"
+}
+function critical { LEVEL=CRITICAL log "$1"; }
+function error { LEVEL=ERROR log "$1"; }
+function warning { LEVEL=WARNING log "$1"; }
+function info { LEVEL=INFO log "$1"; }
+function debug { LEVEL=DEBUG log "$1"; }
+
+
 function xywh_from_points {
     # FIXME: add a bashlib wrapper for utils (coordinate conversion) to use here
     minx=$((2**32))
@@ -37,12 +54,12 @@ function xywh_from_points {
     for point in $*; do
         pointx=${point%,*}
         pointy=${point#*,}
-        [[ $pointx -lt $minx ]] && minx=$pointx
-        [[ $pointx -gt $maxx ]] && maxx=$pointx
-        [[ $pointy -lt $miny ]] && miny=$pointy
-        [[ $pointy -gt $maxy ]] && maxy=$pointy
+        ((pointx < minx)) && minx=$pointx
+        ((pointx > maxx)) && maxx=$pointx
+        ((pointy < miny)) && miny=$pointy
+        ((pointy > maxy)) && maxy=$pointy
     done
-    echo $(($maxx - $minx)) $((maxy - $miny)) $minx $miny
+    echo $((maxx - minx)) $((maxy - miny)) $minx $miny
 }
 
 function iso8601_date () {
@@ -53,16 +70,15 @@ function image_id_from_fpath {
     local image_in_fpath="$1" in_id="$2" in_pageId="$3"
     
     # find image ID representing the image file in METS
-    # FIXME: add a bashlib wrapper for constants (METS tags) to use here
     # FIXME: extend `ocrd workspace find` with a filter option for FLocat to use here
     options=( sel
-              -N mets=http://www.loc.gov/METS/
-              -N xlink=http://www.w3.org/1999/xlink
+              -N "mets=${NAMESPACES[mets]}"
+              -N "xlink=${NAMESPACES[xlink]}"
               -t -v "//mets:file[starts-with(@MIMETYPE,'image/') and ./mets:FLocat/@xlink:href='${image_in_fpath}']/@ID"
               "${ocrd__argv[mets_file]}" )
     if ! image_in_id=$(xmlstarlet "${options[@]}" | head -1); then
-        echo "WARNING: image URL '${image_in_fpath}' not referenced"\
-             "in METS for input file ID=${in_id} (pageId=${in_pageId})" >&2
+        warning "image URL '${image_in_fpath}' not referenced"\
+                "in METS for input file ID=${in_id} (pageId=${in_pageId})"
         image_in_id="${in_id}-IMG" # fallback
     fi
     echo "$image_in_id"
@@ -72,8 +88,9 @@ function modify_page {
     local namespace="$1" ns_prefix="$2" image_out_fpath="$3" out_fpath="$4" comments="$5"
 
     declare -a options
+    # shellcheck disable=SC2016
     options+=( --no-doc-namespace ed --inplace
-               -N pc="${namespace}"
+               -N "pc=${namespace}"
                # update LastChange date stemp:
                -u '/pc:PcGts/pc:Metadata/pc:LastChange'
                -v "$(iso8601_date)"
@@ -93,6 +110,7 @@ function modify_page {
                # bind previous element to "new-labels":
                --var new-labels '$prev' )
     for key in ${!params[@]}; do
+        # shellcheck disable=SC2016
         options+=( # add another "Label":
                    -s '$new-labels' -t elem -n "${ns_prefix}Label"
                    # bind previous element to "new-label":
@@ -104,7 +122,7 @@ function modify_page {
     done
     # insert/append AlternativeImage:
     if xmlstarlet --no-doc-namespace sel              \
-                  -N pc=${namespace} --quiet       \
+                  -N "pc=${namespace}" --quiet       \
                   -t -v '/pc:PcGts/pc:Page/*'         \
                   "$out_fpath"; then
         # something exists: insert before
@@ -113,6 +131,7 @@ function modify_page {
         # nothing here yet: append subnode
         options+=( -s '/pc:PcGts/pc:Page' )
     fi
+    # shellcheck disable=SC2016
     options+=( -t elem -n "${ns_prefix}AlternativeImage"
                --var new-image '$prev'
                -s '$new-image' -t attr -n filename
@@ -127,17 +146,16 @@ function process_pagefile {
     local in_fpath="$1" in_id="$2" in_pageId="$3" out_fpath="$4" out_id="$5" image_out_file_grp="$6"
     local image_in_fpath image_in_id image_out_fpath image_out_id comments
     
-    if (($PRESERVE_NAMESPACE)); then
+    if ((PRESERVE_NAMESPACE)); then
         # preserve namespace and prefix
         cat <"$in_fpath" >"$out_fpath"
     else
         # stylesheet transforms to standard namespace:
-        # FIXME: add a bashlib wrapper for constants (page NAMESPACE) to use here
-        cat <<"EOF" >convert-namespace.xsl
+        cat <<EOF >convert-namespace.xsl
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <xsl:stylesheet version="1.0"
-  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-  xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15">
+  xmlns:xsl="${NAMESPACES[xsl]}"
+  xmlns="${NAMESPACES[page]}">
   <xsl:output method="xml" version="1.0" 
     encoding="UTF-8" indent="yes"/>
   <xsl:template match="@*|text()|comment()|processing-instruction()">
@@ -165,35 +183,36 @@ EOF
     declare -a options
     # find image file representing the page in PAGE
     if options=( --no-doc-namespace sel
-                 -N pc="${namespace}" -t 
+                 -N "pc=${namespace}" -t 
                  -v '/pc:PcGts/pc:Page/pc:AlternativeImage[last()]/@filename' 
                  "$out_fpath" )
        image_in_fpath=$(xmlstarlet "${options[@]}"); then
-        echo "INFO: found AlternativeImage filename '${image_in_fpath}'"\
-             "for input file ID=${in_id} (pageId=${in_pageId})" >&2
+        info "found AlternativeImage filename '${image_in_fpath}'"\
+             "for input file ID=${in_id} (pageId=${in_pageId})"
         image_in_id=$(image_id_from_fpath "$image_in_fpath" "$in_id" "$in_pageId")
         options=( --no-doc-namespace sel
-                  -N pc="${namespace}" -t 
+                  -N "pc=${namespace}" -t 
                   -v '/pc:PcGts/pc:Page/pc:AlternativeImage[last()]/@comments' 
                   "$out_fpath" )
         comments=$(xmlstarlet "${options[@]}"),binarized
     else
         options=( --no-doc-namespace sel
-                  -N pc="${namespace}" -t
+                  -N "pc=${namespace}" -t
                   -v '/pc:PcGts/pc:Page/@imageFilename'
                   "$out_fpath" )
         image_in_fpath=$(xmlstarlet "${options[@]}")
-        echo "INFO: found imageFilename '${image_in_fpath}'"\
-             "for input file ID=${in_id} (pageId=${in_pageId})" >&2
+        info "found imageFilename '${image_in_fpath}'"\
+             "for input file ID=${in_id} (pageId=${in_pageId})"
         image_in_id=$(image_id_from_fpath "$image_in_fpath" "$in_id" "$in_pageId")
         if options=( --no-doc-namespace sel
-                     -N pc="${namespace}" -t
+                     -N "pc=${namespace}" -t
                      -v '(/pc:PcGts/pc:Page/pc:Border|/pc:PcGts/pc:Page/pc:PrintSpace)/pc:Coords/@points'
                      "$out_fpath" )
            border=$(xmlstarlet "${options[@]}"); then
-            echo "DEBUG: Using explicitly set page border '$border'"\
-                 "for input file ID=${in_id} (pageId=${in_pageId})" >&2
-            local tmpfile=$(mktemp --tmpdir ocrd-olena-binarize-cropped.XXXXXX)
+            debug "Using explicitly set page border '$border'"\
+                  "for input file ID=${in_id} (pageId=${in_pageId})"
+            local tmpfile
+            tmpfile=$(mktemp --tmpdir ocrd-olena-binarize-cropped.XXXXXX)
             xywh_from_points $border | {
                 read width height left top 
                 convert "$image_in_fpath" -crop ${width}x${height}+${left}+${top} "$tmpfile"
@@ -271,10 +290,10 @@ function process_imagefile {
     # FIXME: add a bashlib wrapper for page_from_file to use here
     cat <<EOF > "$out_fpath"
 <?xml version="1.0" encoding="UTF-8"?>
-<PcGts xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<PcGts xmlns:xsl="${NAMESPACES[xsl]}"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15"
-  xsi:schemaLocation="http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15 http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15/pagecontent.xsd">
+  xmlns="${NAMESPACES[page]}"
+  xsi:schemaLocation="${NAMESPACES[page]} ${NAMESPACES[page]}/pagecontent.xsd">
   <Metadata>
     <Creator>OCR-D/core $(versionstring=($(ocrd --version)); echo ${versionstring[-1]})</Creator>
     <Created>$(iso8601_date)</Created>
@@ -283,15 +302,16 @@ function process_imagefile {
   <Page imageFilename="$in_fpath" imageWidth="$imageWidth" imageHeight="$imageHeight" type="content"/>
 </PcGts>
 EOF
-    modify_page "http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15" "" "$image_out_fpath" "$out_fpath" "binarized"
+    modify_page "${NAMESPACES[page]}" "" "$image_out_fpath" "$out_fpath" "binarized"
 
     return 0
 }
     
 function main {
-    source `ocrd bashlib filename`
+    # Load ocrd bashlib functions
+    # shellcheck source=../core/ocrd/bashlib/lib.bash
+    source $(ocrd bashlib filename)
     ocrd__wrap "$SHAREDIR/ocrd-tool.json" "ocrd-olena-binarize" "$@"
-    # FIXME: add a bashlib wrapper for logging to use here
 
     cd "${ocrd__argv[working_dir]}"
     page_id=${ocrd__argv[page_id]:-}
@@ -301,12 +321,10 @@ function main {
     image_out_file_grp=${out_file_grp##*,}
     if [ x$image_out_file_grp = x$out_file_grp ];then
         image_out_file_grp=$FALLBACK_IMAGE_FILEGRP
-        echo >&2 "INFO: No output file group for images specified, falling back to '$image_out_file_grp'"
+        info "No output file group for images specified, falling back to '$image_out_file_grp'"
     fi
     mkdir -p $page_out_file_grp
     mkdir -p $image_out_file_grp
-    # FIXME: add a bashlib wrapper for constants (MIMETYPE_PAGE) to use here
-    MIMETYPE_PAGE=application/vnd.prima.page+xml
 
     local IFS=$'\n'
     files=($(ocrd workspace find     \
@@ -332,7 +350,7 @@ function main {
         local in_pageId="${fields[3]:-}"
 
         if ! test -f "$in_fpath"; then
-           echo "ERROR: input file ID=${in_id} (pageId=${in_pageId} MIME=${in_mimetype}) is not on disk" >&2
+           error "input file ID=${in_id} (pageId=${in_pageId} MIME=${in_mimetype}) is not on disk"
            continue
         fi 
 
@@ -343,11 +361,13 @@ function main {
         local out_fpath="$page_out_file_grp/${out_id}.xml"
 
         if [ "x${in_mimetype}" = x${MIMETYPE_PAGE} ]; then
+            info "processing PAGE-XML input file $in_id ($in_pageId)"
             process_pagefile "$in_fpath" "$in_id" "$in_pageId" "$out_fpath" "$out_id" "$image_out_file_grp"
         elif [ "${in_mimetype}" != "${in_mimetype#image/}" ]; then
+            info "processing $in_mimetype input file $in_id ($in_pageId)"
             process_imagefile "$in_fpath" "$in_id" "$in_pageId" "$out_fpath" "$out_id" "$image_out_file_grp"
         else
-            echo "ERROR: input file ID=${in_id} (pageId=${in_pageId} MIME=${in_mimetype}) is neither an image nor a PAGE-XML file" >&2
+            error "input file ID=${in_id} (pageId=${in_pageId} MIME=${in_mimetype}) is neither an image nor a PAGE-XML file"
             continue
         fi
 

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -89,12 +89,12 @@ function modify_page {
                -s '$new-item' -t attr -n value
                               -v "ocrd-olena-binarize"
                # add "Labels":
-               -s '$new-item' -t elem -n Labels
+               -s '$new-item' -t elem -n "${ns_prefix}Labels"
                # bind previous element to "new-labels":
                --var new-labels '$prev' )
     for key in ${!params[@]}; do
         options+=( # add another "Label":
-                   -s '$new-labels' -t elem -n Label
+                   -s '$new-labels' -t elem -n "${ns_prefix}Label"
                    # bind previous element to "new-label":
                    --var new-label '$prev'
                    -s '$new-label' -t attr -n value

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -228,7 +228,7 @@ EOF
     image_out_id="${image_in_id}-BIN_${params[impl]}"
     image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
 
-    scribo-cli "${params[impl]}" "${image_in_fpath}" "${image_out_fpath}" --enable-negate-output
+    scribo-cli "${params[impl]}" "${image_in_fpath}" "${image_out_fpath}" "${scribo_options[@]}"
     
     # Add image file to METS
     ocrd workspace add        \
@@ -252,24 +252,6 @@ function process_imagefile {
     image_out_id="${out_id}-BIN_${params[impl]}"
     image_out_fpath="${image_out_file_grp}/${image_out_id}.png"
 
-    scribo_options=(--enable-negate-output)
-    case ${params[impl]} in
-        otsu)
-            : # has no options whatsoever
-            ;;
-        niblack)
-            scribo_options+=(--disable-negate-input)
-            ;& # fall through
-        sauvola|kim|wolf|singh)
-            scribo_options+=(--k ${params[k]})
-            ;;& # get more
-        sauvola-ms*)
-            scribo_options+=(--all-k ${params[k]})
-            ;;& # get more
-        *)
-            scribo_options+=(--win-size ${params[win-size]})
-            ;;
-    esac
     scribo-cli "${params[impl]}" "${in_fpath}" "${image_out_fpath}" "${scribo_options[@]}"
 
     # Add image file to METS
@@ -313,6 +295,25 @@ function main {
     source $(ocrd bashlib filename)
     ocrd__wrap "$SHAREDIR/ocrd-tool.json" "ocrd-olena-binarize" "$@"
 
+    scribo_options=(--enable-negate-output)
+    case ${params[impl]} in
+        otsu)
+            : # has no options whatsoever
+            ;;
+        niblack)
+            scribo_options+=(--disable-negate-input)
+            ;& # fall through
+        sauvola|kim|wolf|singh)
+            scribo_options+=(--k ${params[k]})
+            ;;& # get more
+        sauvola-ms*)
+            scribo_options+=(--all-k ${params[k]})
+            ;;& # get more
+        *)
+            scribo_options+=(--win-size ${params[win-size]})
+            ;;
+    esac
+    
     cd "${ocrd__argv[working_dir]}"
     page_id=${ocrd__argv[page_id]:-}
     in_file_grp=${ocrd__argv[input_file_grp]}

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -276,6 +276,7 @@ function main {
     # FIXME: add a bashlib wrapper for logging to use here
 
     cd "${ocrd__argv[working_dir]}"
+    page_id=${ocrd__argv[page_id]:-}
     in_file_grp=${ocrd__argv[input_file_grp]}
     out_file_grp=${ocrd__argv[output_file_grp]}
     page_out_file_grp=${out_file_grp%%,*}
@@ -291,6 +292,7 @@ function main {
 
     local IFS=$'\n'
     files=($(ocrd workspace find     \
+                  ${page_id:+-g} ${page_id:-} \
                   -G $in_file_grp    \
                   -k local_filename  \
                   -k ID              \

--- a/olena-add-bin-negate-toggles.patch
+++ b/olena-add-bin-negate-toggles.patch
@@ -1,0 +1,477 @@
+commit e0fc4dc9d8679f359fcfb46f6109204f5bb3e699
+Author: Robert Sachunsky <sachunsky@informatik.uni-leipzig.de>
+Date:   Thu Dec 12 14:55:15 2019 +0100
+
+    scribo-cli binarization: add negate-output toggles uniformly
+    
+        - add `negate-input` / `negate-output` toggles from otsu
+          to other algorithm CLIs too
+          (but keep `negate` as synonym for `negate-output` in sauvola;
+           and don't add `negate-input` where this would require
+           negation on RGB)
+        - use the versatile io::magick::save instead of just io::pbm::save
+        - rename output argument to `output.*` to reflect versatility
+
+diff --git scribo/src/binarization/global_threshold.cc scribo/src/binarization/global_threshold.cc
+index be2cbe0b5..44c565061 100644
+--- scribo/src/binarization/global_threshold.cc
++++ scribo/src/binarization/global_threshold.cc
+@@ -26,10 +26,11 @@
+ 
+ #include <mln/core/image/image2d.hh>
+ #include <mln/value/int_u8.hh>
+-#include <mln/io/magick/load.hh>
+-#include <mln/io/pbm/save.hh>
++#include <mln/io/magick/all.hh>
+ #include <mln/data/transform.hh>
+ #include <mln/fun/v2v/rgb_to_luma.hh>
++#include <mln/arith/revert.hh>
++#include <mln/logical/not.hh>
+ 
+ #include <scribo/binarization/global_threshold.hh>
+ #include <scribo/debug/option_parser.hh>
+@@ -39,7 +40,7 @@ static const scribo::debug::arg_data arg_desc[] =
+ {
+   { "input.*", "An image." },
+   { "threshold_value", "Global threshold to apply." },
+-  { "output.pbm", "A binary image." },
++  { "output.*", "A binary image." },
+   {0, 0}
+ };
+ 
+@@ -48,6 +49,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  { "negate-input", "Negate input image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   {0, 0, false}
+ };
+ 
+@@ -94,8 +97,14 @@ int main(int argc, char *argv[])
+   image2d<value::int_u8>
+     input_1_gl = data::transform(input, mln::fun::v2v::rgb_to_luma<value::int_u8>());
+ 
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1_gl);
++  
+   image2d<bool> out = scribo::binarization::global_threshold(input_1_gl, threshold);
+ 
+-  io::pbm::save(out, options.arg("output.pbm"));
++  if (options.is_enabled("negate-output"))
++    logical::not_inplace(out);
++  
++  io::magick::save(out, options.arg("output.*"));
+ 
+ }
+diff --git scribo/src/binarization/kim.cc scribo/src/binarization/kim.cc
+index 3008796da..b947e98b1 100644
+--- scribo/src/binarization/kim.cc
++++ scribo/src/binarization/kim.cc
+@@ -32,6 +32,8 @@
+ #include <mln/io/magick/all.hh>
+ #include <mln/data/transform.hh>
+ #include <mln/fun/v2v/rgb_to_luma.hh>
++#include <mln/arith/revert.hh>
++#include <mln/logical/not.hh>
+ #include <scribo/binarization/kim.hh>
+ #include <scribo/debug/option_parser.hh>
+ #include <scribo/debug/logger.hh>
+@@ -49,6 +51,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  { "negate-input", "Negate input image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   {0, 0, false}
+ };
+ 
+@@ -106,8 +110,14 @@ int main(int argc, char *argv[])
+     input_1_gl = data::transform(input_1,
+ 				 mln::fun::v2v::rgb_to_luma<value::int_u8>());
+ 
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1_gl);
++
+   image2d<bool>
+     output = scribo::binarization::kim(input_1_gl, w_1, k);
+ 
++  if (options.is_enabled("negate-output"))
++    logical::not_inplace(output);
++
+   io::magick::save(output, options.arg("output.*"));
+ }
+diff --git scribo/src/binarization/niblack.cc scribo/src/binarization/niblack.cc
+index a528eb81b..5f6e9b5ee 100644
+--- scribo/src/binarization/niblack.cc
++++ scribo/src/binarization/niblack.cc
+@@ -39,7 +39,7 @@
+ static const scribo::debug::arg_data arg_desc[] =
+ {
+   { "input.*", "An image." },
+-  { "output.pbm", "A binary image." },
++  { "output.*", "A binary image." },
+   {0, 0}
+ };
+ 
+@@ -48,6 +48,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  { "negate-input", "Negate input image before binarizing.", true },
++  { "negate-output", "Negate output image after binarizing.", true },
+   {0, 0, false}
+ };
+ 
+@@ -97,9 +99,11 @@ int main(int argc, char *argv[])
+   image2d<value::int_u8>
+     input_1_gl = data::transform(input, mln::fun::v2v::rgb_to_luma<value::int_u8>());
+ 
+-  arith::revert_inplace(input_1_gl);
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1_gl);
+   image2d<bool> out = scribo::binarization::niblack(input_1_gl, w, k);
+-  logical::not_inplace(out);
+-  io::magick::save(out, options.arg("output.pbm"));
++  if (options.is_enabled("negate-output"))
++    logical::not_inplace(out);
++  io::magick::save(out, options.arg("output.*"));
+ 
+ }
+diff --git scribo/src/binarization/otsu.cc scribo/src/binarization/otsu.cc
+index b2a9d57d3..e5cf3fcc3 100644
+--- scribo/src/binarization/otsu.cc
++++ scribo/src/binarization/otsu.cc
+@@ -39,7 +39,7 @@
+ static const scribo::debug::arg_data arg_desc[] =
+ {
+   { "input.*", "An image." },
+-  { "output.pbm", "A binary image." },
++  { "output.*", "A binary image." },
+   {0, 0}
+ };
+ 
+@@ -49,7 +49,7 @@ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
+   { "negate-input", "Negate input image before binarizing.", false },
+-  { "negate-output", "Negate output image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   {0, 0, false}
+ };
+ 
+@@ -96,13 +96,13 @@ int main(int argc, char *argv[])
+     input_1_gl = data::transform(input, mln::fun::v2v::rgb_to_luma<value::int_u8>());
+ 
+   if (options.is_enabled("negate-input"))
+-    input_1_gl = arith::revert(input_1_gl);
++    arith::revert_inplace(input_1_gl);
+ 
+   image2d<bool> out = scribo::binarization::otsu(input_1_gl);
+ 
+   if (options.is_enabled("negate-output"))
+     logical::not_inplace(out);
+ 
+-  io::magick::save(out, options.arg("output.pbm"));
++  io::magick::save(out, options.arg("output.*"));
+ 
+ }
+diff --git scribo/src/binarization/sauvola.cc scribo/src/binarization/sauvola.cc
+index 603b815a4..dd0f4ef45 100644
+--- scribo/src/binarization/sauvola.cc
++++ scribo/src/binarization/sauvola.cc
+@@ -29,6 +29,8 @@
+ #include <mln/io/magick/all.hh>
+ #include <mln/data/transform.hh>
+ #include <mln/fun/v2v/rgb_to_luma.hh>
++#include <mln/arith/revert.hh>
++#include <mln/logical/not.hh>
+ 
+ #include <scribo/binarization/sauvola.hh>
+ #include <scribo/debug/option_parser.hh>
+@@ -46,6 +48,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  { "negate-input", "Negate input image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   {0, 0, false}
+ };
+ 
+@@ -95,6 +99,9 @@ int main(int argc, char *argv[])
+   image2d<value::int_u8>
+     input_1_gl = data::transform(input, mln::fun::v2v::rgb_to_luma<value::int_u8>());
+ 
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1_gl);
++
+   scribo::debug::logger().start_time_logging();
+ 
+   // Binarize
+@@ -102,6 +109,9 @@ int main(int argc, char *argv[])
+ 
+   scribo::debug::logger().stop_time_logging("Binarized in");
+ 
++  if (options.is_enabled("negate-output"))
++    logical::not_inplace(out);
++
+   io::magick::save(out, options.arg("output.*"));
+ 
+ }
+diff --git scribo/src/binarization/sauvola_ms.cc scribo/src/binarization/sauvola_ms.cc
+index c81509ca1..e16b89dd4 100644
+--- scribo/src/binarization/sauvola_ms.cc
++++ scribo/src/binarization/sauvola_ms.cc
+@@ -30,6 +30,7 @@
+ #include <mln/value/int_u8.hh>
+ #include <mln/io/magick/all.hh>
+ #include <mln/data/transform.hh>
++#include <mln/arith/revert.hh>
+ #include <mln/fun/v2v/rgb_to_luma.hh>
+ #include <mln/util/timer.hh>
+ #include <mln/logical/not.hh>
+@@ -50,6 +51,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  { "negate-input", "Negate input image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   { "negate", "Negate output image.", false},
+   {0, 0, false}
+ };
+@@ -137,6 +140,8 @@ int main(int argc, char *argv[])
+     input_1_gl = data::transform(input_1,
+ 				 mln::fun::v2v::rgb_to_luma<value::int_u8>());
+ 
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1_gl);
+ 
+   scribo::debug::logger().start_time_logging();
+ 
+@@ -146,8 +151,8 @@ int main(int argc, char *argv[])
+ 
+   scribo::debug::logger().stop_time_logging("Binarized in");
+ 
+-  if (options.is_enabled("negate"))
+-    io::magick::save(logical::not_(output), options.arg("output.*"));
+-  else
+-    io::magick::save(output, options.arg("output.*"));
++  if (options.is_enabled("negate") || options.is_enabled("negate-output"))
++    logical::not_inplace(output);
++  
++  io::magick::save(output, options.arg("output.*"));
+ }
+diff --git scribo/src/binarization/sauvola_ms_fg.cc scribo/src/binarization/sauvola_ms_fg.cc
+index 5566e4128..1bb8e423f 100644
+--- scribo/src/binarization/sauvola_ms_fg.cc
++++ scribo/src/binarization/sauvola_ms_fg.cc
+@@ -28,10 +28,11 @@
+ 
+ #include <mln/core/image/image2d.hh>
+ #include <mln/value/rgb8.hh>
+-#include <mln/io/magick/load.hh>
+-#include <mln/io/pbm/save.hh>
++#include <mln/io/magick/all.hh>
+ #include <mln/data/transform.hh>
+ #include <mln/fun/v2v/rgb_to_luma.hh>
++#include <mln/arith/revert.hh>
++#include <mln/logical/not.hh>
+ 
+ #include <scribo/binarization/sauvola_ms.hh>
+ #include <scribo/preprocessing/split_bg_fg.hh>
+@@ -41,7 +42,7 @@
+ static const scribo::debug::arg_data arg_desc[] =
+ {
+   { "input.*", "An image." },
+-  { "output.pbm", "A binary image." },
++  { "output.*", "A binary image." },
+   {0, 0}
+ };
+ 
+@@ -50,6 +51,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  // { "negate-input", "Negate input image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   {0, 0, false}
+ };
+ 
+@@ -130,6 +133,11 @@ int main(int argc, char *argv[])
+   image2d<value::rgb8> input_1;
+   io::magick::load(input_1, options.arg("input.*"));
+ 
++  /*
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1);
++  */
++  
+   // Split foreground/background
+   image2d<value::rgb8>
+     fg = scribo::preprocessing::split_bg_fg(input_1, lambda, 32).first();
+@@ -142,7 +150,10 @@ int main(int argc, char *argv[])
+   image2d<bool>
+     output = scribo::binarization::sauvola_ms(fg_gl, w_1, s);
+ 
+-  io::pbm::save(output, options.arg("output.pbm"));
++  if (options.is_enabled("negate-output"))
++    logical::not_inplace(output);
++  
++  io::magick::save(output, options.arg("output.*"));
+ }
+ 
+ 
+diff --git scribo/src/binarization/sauvola_ms_split.cc scribo/src/binarization/sauvola_ms_split.cc
+index db3290821..7443df364 100644
+--- scribo/src/binarization/sauvola_ms_split.cc
++++ scribo/src/binarization/sauvola_ms_split.cc
+@@ -26,8 +26,10 @@
+ 
+ #include <mln/core/image/image2d.hh>
+ #include <mln/value/rgb8.hh>
+-#include <mln/io/magick/load.hh>
+-#include <mln/io/pbm/save.hh>
++#include <mln/io/magick/all.hh>
++#include <mln/arith/revert.hh>
++#include <mln/logical/not.hh>
++
+ 
+ #include <scribo/binarization/sauvola_ms_split.hh>
+ #include <scribo/debug/option_parser.hh>
+@@ -36,7 +38,7 @@
+ static const scribo::debug::arg_data arg_desc[] =
+ {
+   { "input.*", "An image." },
+-  { "output.pbm", "A binary image." },
++  { "output.*", "A binary image." },
+   {0, 0}
+ };
+ 
+@@ -45,6 +47,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  // { "negate-input", "Negate input image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   {0, 0, false}
+ };
+ 
+@@ -124,10 +128,18 @@ int main(int argc, char *argv[])
+   image2d<value::rgb8> input_1;
+   io::magick::load(input_1, options.arg("input.*"));
+ 
++  /*
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1);
++  */
++
+   image2d<bool>
+     output = scribo::binarization::sauvola_ms_split(input_1, w_1, s, min_ntrue);
+ 
+-  io::pbm::save(output, options.arg("output.pbm"));
++  if (options.is_enabled("negate-output"))
++    logical::not_inplace(output);
++
++  io::magick::save(output, options.arg("output.*"));
+ }
+ 
+ 
+diff --git scribo/src/binarization/singh.cc scribo/src/binarization/singh.cc
+index 66643e4c2..927a469f7 100644
+--- scribo/src/binarization/singh.cc
++++ scribo/src/binarization/singh.cc
+@@ -26,10 +26,11 @@
+ 
+ #include <mln/core/image/image2d.hh>
+ #include <mln/value/int_u8.hh>
+-#include <mln/io/magick/load.hh>
+-#include <mln/io/pbm/save.hh>
++#include <mln/io/magick/all.hh>
+ #include <mln/data/transform.hh>
+ #include <mln/fun/v2v/rgb_to_luma.hh>
++#include <mln/arith/revert.hh>
++#include <mln/logical/not.hh>
+ 
+ #include <scribo/binarization/singh.hh>
+ #include <scribo/debug/option_parser.hh>
+@@ -38,7 +39,7 @@
+ static const scribo::debug::arg_data arg_desc[] =
+ {
+   { "input.*", "An image." },
+-  { "output.pbm", "A binary image." },
++  { "output.*", "A binary image." },
+   {0, 0}
+ };
+ 
+@@ -47,6 +48,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  { "negate-input", "Negate input image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   {0, 0, false}
+ };
+ 
+@@ -96,8 +99,14 @@ int main(int argc, char *argv[])
+   image2d<value::int_u8>
+     input_1_gl = data::transform(input, mln::fun::v2v::rgb_to_luma<value::int_u8>());
+ 
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1_gl);
++
+   image2d<bool> out = scribo::binarization::singh(input_1_gl, w, k);
+ 
+-  io::pbm::save(out, options.arg("output.pbm"));
++  if (options.is_enabled("negate-output"))
++    logical::not_inplace(out);
++
++  io::magick::save(out, options.arg("output.*"));
+ 
+ }
+diff --git scribo/src/binarization/wolf.cc scribo/src/binarization/wolf.cc
+index e4819e8e8..e913a9c4f 100644
+--- scribo/src/binarization/wolf.cc
++++ scribo/src/binarization/wolf.cc
+@@ -29,6 +29,8 @@
+ #include <mln/io/magick/all.hh>
+ #include <mln/data/transform.hh>
+ #include <mln/fun/v2v/rgb_to_luma.hh>
++#include <mln/arith/revert.hh>
++#include <mln/logical/not.hh>
+ 
+ #include <scribo/binarization/wolf.hh>
+ #include <scribo/debug/option_parser.hh>
+@@ -37,7 +39,7 @@
+ static const scribo::debug::arg_data arg_desc[] =
+ {
+   { "input.*", "An image." },
+-  { "output.pbm", "A binary image." },
++  { "output.*", "A binary image." },
+   {0, 0}
+ };
+ 
+@@ -46,6 +48,8 @@ static const scribo::debug::arg_data arg_desc[] =
+ static const scribo::debug::toggle_data toggle_desc[] =
+ {
+   // name, description, default value
++  { "negate-input", "Negate input image before binarizing.", false },
++  { "negate-output", "Negate output image after binarizing.", false },
+   {0, 0, false}
+ };
+ 
+@@ -95,8 +99,14 @@ int main(int argc, char *argv[])
+   image2d<value::int_u8>
+     input_1_gl = data::transform(input, mln::fun::v2v::rgb_to_luma<value::int_u8>());
+ 
++  if (options.is_enabled("negate-input"))
++    arith::revert_inplace(input_1_gl);
++
+   image2d<bool> out = scribo::binarization::wolf(input_1_gl, w, k);
+ 
+-  io::magick::save(out, options.arg("output.pbm"));
++  if (options.is_enabled("negate-output"))
++    logical::not_inplace(out);
++
++  io::magick::save(out, options.arg("output.*"));
+ 
+ }

--- a/test/test.sh
+++ b/test/test.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -e
-export PATH="$PWD/..:$PWD/../local/bin:$PATH"
 export assets="$PWD/assets/data"
 export workspace_dir="/tmp/test-ocrd-olena-binarize"
 

--- a/test/test.sh
+++ b/test/test.sh
@@ -22,7 +22,7 @@ done
 
 for algo in "${algos[@]}";do
     echo >&2 "# Diffing $algo image binary size"
-    should=$(wc -c "$workspace_dir"/OCR-D-IMG-BIN-${algo}/*.png | grep -o '^[0-9]*')
+    should=$(wc -c "$workspace_dir"/OCR-D-IMG-BIN-${algo^^}/*.png | grep -o '^[0-9]*')
     actual=$(wc -c "$assets"/scribo-test/data/OCR-D-IMG-BIN-${algo^^}/* | grep -o '^[0-9]*')
     if [[ $should != $actual ]];then
         echo "not ok - $algo: Expected $should but is $actual"

--- a/test/test.sh
+++ b/test/test.sh
@@ -22,13 +22,14 @@ done
 
 for algo in "${algos[@]}";do
     echo >&2 "# Diffing $algo image binary size"
-    should=$(wc -c "$workspace_dir"/OCR-D-IMG-BIN-${algo^^}/*.png | grep -o '^[0-9]*')
-    actual=$(wc -c "$assets"/scribo-test/data/OCR-D-IMG-BIN-${algo^^}/* | grep -o '^[0-9]*')
-    if [[ $should != $actual ]];then
-        echo "not ok - $algo: Expected $should but is $actual"
+    if ! compare -metric mae \
+        "$workspace_dir"/OCR-D-IMG-BIN-${algo^^}/*.png \
+        "$assets"/scribo-test/data/OCR-D-IMG-BIN-${algo^^}/* \
+        /dev/null; then
+        echo "not ok - $algo: Images differ"
         false
     else
-        echo "ok - $algo: Matches $should == $actual"
+        echo "ok - $algo: Images Match"
     fi
     echo >&2 "# Checking $algo PAGE result"
     # roughly check output fileGrp and comments:


### PR DESCRIPTION
No need for `convert` anymore. (Was missing in `deps-ubuntu` anyway.)

I am afraid we have to update the tests now, because we get diffferent PNG metadata (addtiional chromicity tag, no text tag). The images themselves look ok though.

(But before we touch the tests, we should fix and apply OCR-D/assets#64 though.)