### PR TITLE
update test/assets (lowercase filenames only during test)

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -23,7 +23,7 @@ done
 for algo in "${algos[@]}";do
     echo >&2 "# Diffing $algo image binary size"
     if ! compare -metric mae \
-        "$workspace_dir"/OCR-D-IMG-BIN-${algo^^}/*.png \
+        "$workspace_dir"/OCR-D-IMG-BIN-${algo}/*.png \
         "$assets"/scribo-test/data/OCR-D-IMG-BIN-${algo^^}/* \
         /dev/null; then
         echo "not ok - $algo: Images differ"


### PR DESCRIPTION
...to get things going for macOS case-insensitive FS.

@stweil, I had to redefine the scribo-test comparison: you have removed the lowercase variants from assets, but left the comparison of uppercase assets with uppercase workspace. The workspace outputs are in lowercase, however.