### PR TITLE
make build-olena: --disable-doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,7 @@ $(BUILD_DIR)/config.status: $(OLENA_DIR)/configure
 		cd $(BUILD_DIR) && \
 		$(OLENA_DIR)/configure \
 			--prefix=$(PREFIX) \
+			--disable-doc \
 			--disable-dependency-tracking \
 			--with-tesseract=no \
 			--enable-scribo SCRIBO_CXXFLAGS="-DNDEBUG -DSCRIBO_NDEBUG -O2"


### PR DESCRIPTION
Somehow missed comitting to #35 

If `rst2html` is not installed, documentation won't be built though:

[`configure: WARNING: rst2html not found, documentation rebuild will not be possible`](https://circleci.com/gh/OCR-D/ocrd_olena/31)