### PR TITLE
pass `file://` prefix in absolute pathnames

### DIFF
--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -290,7 +290,7 @@ function process_imagefile {
     <Created>$(iso8601_date)</Created>
     <LastChange/>
   </Metadata>
-  <Page imageFilename="${in_fpath#file://}" imageWidth="$imageWidth" imageHeight="$imageHeight" type="content"/>
+  <Page imageFilename="$in_fpath" imageWidth="$imageWidth" imageHeight="$imageHeight" type="content"/>
 </PcGts>
 EOF
     modify_page "${NAMESPACES[page]}" "" "$image_out_fpath" "$out_fpath" "binarized"


### PR DESCRIPTION
To (really) fix #38.

Note: this delegates when a prefix is appropriate or not to the workspace's `OcrdFile.url` data. We just pass on what's there unchanged here.