### PR TITLE
ocrd-olena-binarize: filter binarized input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Versioned according to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+Changed:
+
+  * skip `AlternativeImage/@comments=binarized` in PAGE input
+
 ## [1.1.5] - 2020-03-19
 
 Fixed:

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -191,18 +191,19 @@ EOF
     # find image file representing the page in PAGE
     if options=( --no-doc-namespace sel
                  -N "pc=${namespace}" -t 
-                 -v '/pc:PcGts/pc:Page/pc:AlternativeImage[last()]/@filename' 
+                 -v '/pc:PcGts/pc:Page/pc:AlternativeImage[not(contains(@comments,"binarized"))][last()]/@filename'
                  "$out_fpath" )
        image_in_fpath=$(xmlstarlet "${options[@]}"); then
-        info "found AlternativeImage filename '${image_in_fpath}'"\
+        options=( --no-doc-namespace sel
+                  -N "pc=${namespace}" -t 
+                  -v "/pc:PcGts/pc:Page/pc:AlternativeImage[@filename=\"${image_in_fpath}\"]/@comments"
+                  "$out_fpath" )
+        comments=$(xmlstarlet "${options[@]}")
+        info "found AlternativeImage filename '${image_in_fpath}' ($comments)"\
              "for input file ID=${in_id} (pageId=${in_pageId})"
         image_in_id=$(image_id_from_fpath "$image_in_fpath" "$in_id" "$in_pageId")
         image_in_fpath="${image_in_fpath#file://}"
-        options=( --no-doc-namespace sel
-                  -N "pc=${namespace}" -t 
-                  -v '/pc:PcGts/pc:Page/pc:AlternativeImage[last()]/@comments' 
-                  "$out_fpath" )
-        comments=$(xmlstarlet "${options[@]}"),binarized
+        comments="$comments"${comments:+,}binarized
     else
         options=( --no-doc-namespace sel
                   -N "pc=${namespace}" -t


### PR DESCRIPTION
(If input fileGrp is PAGE-XML, prefer the last `AlternativeImage` that is _not_ already binarized.)

This helps workflows like [this](https://github.com/bertsky/workflow-configuration/blob/b2b466aa7032a20fb037bfb12e3a40e72da791ce/crop-anyocr-binarize-page-olena-sauvola-denoise-ocropy-deskew-page-ocropy-segment-tesseract-ocropy-dewarp-ocr-ocropy-tesseract.mk#L47) where we want to re-binarize from raw image (e.g. page image without margins after cropping, region image isolated from graphic regions, line image isolated from others).

The old behaviour just picked the very last AlternativeImage, which could already have been binarized.  (I don't see a use-case to re-binarize from binary images).