### PR TITLE
ocrd-olena-binarize: Change 'python' call to 'python3'

### DIFF
--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -313,19 +313,19 @@ function main {
         niblack)
             scribo_options+=(--disable-negate-input)
             # has default -0.2 not 0.34
-            scribo_options+=(--k $(python -c "print(${params[k]}/-1.7)"))
+            scribo_options+=(--k $(python3 -c "print(${params[k]}/-1.7)"))
             ;& # fall through
         sauvola|kim|wolf)
             scribo_options+=(--k ${params[k]})
             ;;& # get more
         singh)
             # has default 0.06 not 0.34
-            scribo_options+=(--k $(python -c "print(${params[k]}*0.1765)"))
+            scribo_options+=(--k $(python3 -c "print(${params[k]}*0.1765)"))
             ;;& # get more
         sauvola-ms*)
-            scribo_options+=(--k2 $(python -c "print(${params[k]}/0.34*0.2)")
-                             --k3 $(python -c "print(${params[k]}/0.34*0.3)")
-                             --k4 $(python -c "print(${params[k]}/0.34*0.5)"))
+            scribo_options+=(--k2 $(python3 -c "print(${params[k]}/0.34*0.2)")
+                             --k3 $(python3 -c "print(${params[k]}/0.34*0.3)")
+                             --k4 $(python3 -c "print(${params[k]}/0.34*0.5)"))
             ;;& # get more
         *)
             scribo_options+=(--win-size ${params[win-size]})


### PR DESCRIPTION
Docker image `ocrd/all:maximum` does not include a `/usr/bin/python` link to any python interpreter, causing the script to fail when called e.g. with the parameter `singh`:

```
root@01ca8e5105ab:/workspace# ocrd-olena-binarize -I OCR-D-IMG -O OCR-D-BIN -p '{"impl": "singh"}'
/usr/local/bin/ocrd-olena-binarize: line 323: python: command not found
```

The image includes `/usr/bin/python3`, so this could be fixed by replacing all `python` calls by `python3`.