### PR TITLE
Add pkg-config checks to deps for magick++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,12 +43,17 @@ deps-ubuntu:
 		git g++ make automake \
 		xmlstarlet ca-certificates libmagick++-dev libgraphicsmagick++1-dev libboost-dev
 
+pkg_config_check = $(shell if ! pkg-config --modversion $(1);then echo "$(1) not installed. 'make deps-ubuntu' or 'sudo apt install $(2)'"; exit 1 ; fi)
+
 deps: #deps-ubuntu
 	test -x $(BINDIR)/scribo-cli && \
 	$(BINDIR)/scribo-cli sauvola --help >/dev/null 2>&1 || \
 		$(MAKE) build-olena
 	which ocrd >/dev/null 2>&1 || \
 		$(PIP) install ocrd # needed for ocrd CLI (and bashlib)
+	$(call pkg_config_check,Magick++,libmagick++-dev)
+	$(call pkg_config_check,ImageMagick++,libgraphicsmagick++-dev)
+	# $#(call pkg_config_check,Boost,libboost-dev)
 
 # Install
 install: deps


### PR DESCRIPTION
Unfortunately, Olena's configure script will not stop if magick++ lib is not available and will silently skip installing the implementations of the binarization algorithms. I had a broken installation of `libmagick++-dev` on Ubuntu 18.04 and realizing the root cause of the issue took hours.

This adds a check that `pkg-config` can find `Magick++` and `ImageMagic++`. Unfortunately, not all libraries offer support for pkg-config, Boost notably does not. 