### PR TITLE
Fix build for macOS (old cp command)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ install: $(TOOLS:%=$(BINDIR)/%)
 
 $(SHAREDIR)/ocrd-tool.json: ocrd-tool.json
 	@mkdir -p $(SHAREDIR)
-	cp -t $(SHAREDIR) ocrd-tool.json
+	cp ocrd-tool.json $(SHAREDIR)
 
 $(TOOLS:%=$(BINDIR)/%): $(BINDIR)/%: %
 	@mkdir -p $(BINDIR)


### PR DESCRIPTION
macOS does not support `cp -t`, so change that statement and use simply `cp`.

Signed-off-by: Stefan Weil <sw@weilnetz.de>