### PR TITLE
Try to ensure imageHeight is an integer.

### DIFF
--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -276,8 +276,7 @@ function process_imagefile {
 
     # Reference image file in PAGE
     # FIXME: add a bashlib wrapper for OcrdExif to use here
-    imageInfo=($(identify "$in_fpath"))
-    imageGeometry=${imageInfo[2]}
+    imageGeometry=($(identify -format "%[fx:w]x%[fx:h]" "$in_fpath"))
     imageWidth=${imageGeometry%x*}
     imageHeight=${imageGeometry#*x}
     # FIXME: add a bashlib wrapper for page_from_file to use here


### PR DESCRIPTION
Running into an error in core while validating the image height inserted using `identify`:

`
13:01:30.945 INFO processor.TesserocrSegmentRegion - INPUT FILE 0 / PHYS_0001
13:01:30.946 DEBUG ocrd.workspace - download_file <OcrdFile mimetype=application/vnd.prima.page+xml, ID=FILE_0001_OCR-D-IMG-BINPAGE, url=OCR-D-IMG-BINPAGE/FILE_0001_OCR-D-IMG-BINPAGE.xml, local_filename=OCR-D-IMG-BINPAGE/FILE_0001_OCR-D-IMG-BINPAGE.xml]/>  [_recursion_count=0]
Traceback (most recent call last):
  File "/home/j23d/projects/ocr-d/ocrd_all/venv/lib/python3.7/site-packages/ocrd_models/ocrd_page_generateds.py", line 203, in gds_parse_integer
    ival = int(input_data)
ValueError: invalid literal for int() with base 10: '1136+0+0'`

Better ideas than cutting the offending `+0+0` are welcome, but this works for me.