### PR TITLE
Set pcGtsId in the PAGE-XML output

### DIFF
--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -87,12 +87,15 @@ function image_id_from_fpath {
 }   
 
 function modify_page {
-    local namespace="$1" ns_prefix="$2" image_out_fpath="$3" out_fpath="$4" comments="$5"
+    local namespace="$1" ns_prefix="$2" image_out_fpath="$3" out_fpath="$4" comments="$5" out_id="$6"
 
     declare -a options
     # shellcheck disable=SC2016
     options+=( --no-doc-namespace ed --inplace
                -N "pc=${namespace}"
+               # set pcGtsId:
+               -u '/pc:PcGts/@pcGtsId'
+               -v "${out_id}"
                # update LastChange date stemp:
                -u '/pc:PcGts/pc:Metadata/pc:LastChange'
                -v "$(iso8601_date)"
@@ -251,7 +254,7 @@ EOF
          "$image_out_fpath"
 
     # Reference image file in PAGE
-    modify_page "$namespace" "$ns_prefix" "$image_out_fpath" "$out_fpath" "$comments"
+    modify_page "$namespace" "$ns_prefix" "$image_out_fpath" "$out_fpath" "$comments" "$out_id"
     
     return 0
 }
@@ -285,7 +288,8 @@ function process_imagefile {
 <PcGts xmlns:xsl="${NAMESPACES[xsl]}"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns="${NAMESPACES[page]}"
-  xsi:schemaLocation="${NAMESPACES[page]} ${NAMESPACES[page]}/pagecontent.xsd">
+  xsi:schemaLocation="${NAMESPACES[page]} ${NAMESPACES[page]}/pagecontent.xsd"
+  pcGtsId="${out_id}">
   <Metadata>
     <Creator>OCR-D/core $(versionstring=($(ocrd --version)); echo ${versionstring[-1]})</Creator>
     <Created>$(iso8601_date)</Created>
@@ -294,7 +298,7 @@ function process_imagefile {
   <Page imageFilename="$in_fpath" imageWidth="$imageWidth" imageHeight="$imageHeight" type="content"/>
 </PcGts>
 EOF
-    modify_page "${NAMESPACES[page]}" "" "$image_out_fpath" "$out_fpath" "binarized"
+    modify_page "${NAMESPACES[page]}" "" "$image_out_fpath" "$out_fpath" "binarized" "$out_id"
 
     return 0
 }


### PR DESCRIPTION
Recent ocrd versions want the `pcGtsId` in the PAGE-XML to exist and match the IDs in the METS file. ocrd-olena-binarize did not set any `pcGtsId`, so the output did not validate using `ocrd workspace validate`:

~~~
<report valid="false">
  <warning>pc:PcGts/@pcGtsId differs from mets:file/@ID: "" !== "OCR-D-IMG-BINPAGE_00000227"</warning>
  <warning>pc:PcGts/@pcGtsId differs from mets:file/@ID: "" !== "OCR-D-IMG-BINPAGE_00000228"</warning>
  <warning>pc:PcGts/@pcGtsId differs from mets:file/@ID: "" !== "OCR-D-IMG-BINPAGE_00000229"</warning>
  <warning>pc:PcGts/@pcGtsId differs from mets:file/@ID: "" !== "OCR-D-IMG-BINPAGE_00000230"</warning>
</report>
~~~

Fix this by setting a pcGtsId in the PAGE-XML output.

Fixes #60.