### PR TITLE
support --mets-server-url

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ jobs:
       - run: sudo make deps-ubuntu
       - run: sudo apt-get install imagemagick python3-pip
       - run: make build-olena
+      - run: make deps
+      - run: cat $(ocrd bashlib filename)
       - run: sudo make install PREFIX=/usr/local
       - run: make test
       - run: make docker

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ deps: #deps-ubuntu
 	scribo-cli sauvola --help >/dev/null 2>&1 || \
 		$(MAKE) build-olena
 	$(PIP) install -U pip
-	$(PIP) install "ocrd>=2.58" # needed for ocrd CLI (and bashlib)
+	$(PIP) install "ocrd>=2.58.1" # needed for ocrd CLI (and bashlib)
 
 # Install
 install: deps install-tools

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ deps: #deps-ubuntu
 	scribo-cli sauvola --help >/dev/null 2>&1 || \
 		$(MAKE) build-olena
 	$(PIP) install -U pip
-	$(PIP) install "ocrd>=2.13" # needed for ocrd CLI (and bashlib)
+	$(PIP) install "ocrd>=2.58" # needed for ocrd CLI (and bashlib)
 
 # Install
 install: deps install-tools

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -415,7 +415,12 @@ function main {
     if [[ "${ocrd__argv[overwrite]}" == true ]];then
         bulk_options+=( --force )
     fi
-    ocrd workspace -m "${mets_basename}" bulk-add "${bulk_options[@]}" - <$FIFO &
+
+    workspace_options=( -m "${mets_basename}" )
+    if [[ -n "${ocrd__argv[mets_server_url]}" ]];then
+        workspace_options+=( --mets-server-url "${ocrd__argv[mets_server_url]}" )
+    fi
+    ocrd workspace "${workspace_options[@]}" bulk-add "${bulk_options[@]}" - <$FIFO &
     exec 3>$FIFO
     
     for ((n=0; n<${#ocrd__files[*]}; n++)); do

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -375,7 +375,7 @@ function main {
     # shellcheck source=../core/ocrd/bashlib/lib.bash
     source $(ocrd bashlib filename)
     ocrd__wrap "$SHAREDIR/ocrd-tool.json" "ocrd-olena-binarize" "$@"
-    ocrd__minversion 2.58
+    ocrd__minversion 2.58.0
 
     scribo_options=(--enable-negate-output)
     case ${params[impl]} in

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -375,7 +375,7 @@ function main {
     # shellcheck source=../core/ocrd/bashlib/lib.bash
     source $(ocrd bashlib filename)
     ocrd__wrap "$SHAREDIR/ocrd-tool.json" "ocrd-olena-binarize" "$@"
-    ocrd__minversion 2.55.2
+    ocrd__minversion 2.58
 
     scribo_options=(--enable-negate-output)
     case ${params[impl]} in

--- a/ocrd-olena-binarize
+++ b/ocrd-olena-binarize
@@ -375,7 +375,7 @@ function main {
     # shellcheck source=../core/ocrd/bashlib/lib.bash
     source $(ocrd bashlib filename)
     ocrd__wrap "$SHAREDIR/ocrd-tool.json" "ocrd-olena-binarize" "$@"
-    ocrd__minversion 2.58.0
+    ocrd__minversion 2.58.1
 
     scribo_options=(--enable-negate-output)
     case ${params[impl]} in


### PR DESCRIPTION
In combination with https://github.com/OCR-D/core/pull/1126 this now supports `--mets-server-url`, alleviating the need for the save-process-reload workaround of https://github.com/OCR-D/core/pull/1124